### PR TITLE
[BACKLOG-5343]  Data Service ResultSet implementation mishandles getXXX(String)

### DIFF
--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/ThinResultSet.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/ThinResultSet.java
@@ -73,8 +73,8 @@ public class ThinResultSet implements ResultSet {
   private ThinConnection connection;
 
   private DataInputStream dataInputStream;
-  private RowMetaInterface rowMeta;
-  private Object[] currentRow;
+  protected RowMetaInterface rowMeta;
+  protected Object[] currentRow;
   private int rowNumber;
   private boolean lastNull;
 
@@ -127,6 +127,9 @@ public class ThinResultSet implements ResultSet {
       throw new SQLException(
           "Unable to get open query for SQL: " + sql + Const.CR + Const.getStackTracker( e ), e );
     }
+  }
+
+  protected ThinResultSet() {
   }
 
   private DataInputStream remoteQuery( String urlString, String sql ) throws Exception {
@@ -448,6 +451,7 @@ public class ThinResultSet implements ResultSet {
 
   @Override
   public Date getDate( int index ) throws SQLException {
+    validateIndex( index );
     try {
       java.util.Date date = rowMeta.getDate( currentRow, index - 1 );
       if ( date == null ) {
@@ -463,7 +467,7 @@ public class ThinResultSet implements ResultSet {
 
   @Override
   public Date getDate( String columnName ) throws SQLException {
-    return getDate( rowMeta.indexOfValue( columnName ) );
+    return getDate( rowMeta.indexOfValue( columnName ) + 1 );
   }
 
   @Override
@@ -473,11 +477,12 @@ public class ThinResultSet implements ResultSet {
 
   @Override
   public Date getDate( String columnName, Calendar calendar ) throws SQLException {
-    return getDate( rowMeta.indexOfValue( columnName ) );
+    return getDate( rowMeta.indexOfValue( columnName ) + 1 );
   }
 
   @Override
   public double getDouble( int index ) throws SQLException {
+    validateIndex( index );
     try {
       Double d = rowMeta.getNumber( currentRow, index - 1 );
       if ( d == null ) {
@@ -493,7 +498,7 @@ public class ThinResultSet implements ResultSet {
 
   @Override
   public double getDouble( String columnName ) throws SQLException {
-    return getDouble( rowMeta.indexOfValue( columnName ) );
+    return getDouble( rowMeta.indexOfValue( columnName ) + 1 );
   }
 
   @Override
@@ -518,6 +523,7 @@ public class ThinResultSet implements ResultSet {
 
   @Override
   public BigDecimal getBigDecimal( int index ) throws SQLException {
+    validateIndex( index );
     try {
       BigDecimal d = rowMeta.getBigNumber( currentRow, index - 1 );
       if ( d == null ) {
@@ -533,7 +539,7 @@ public class ThinResultSet implements ResultSet {
 
   @Override
   public BigDecimal getBigDecimal( String columnName ) throws SQLException {
-    return getBigDecimal( rowMeta.indexOfValue( columnName ) );
+    return getBigDecimal( rowMeta.indexOfValue( columnName ) + 1 );
   }
 
   @Override
@@ -545,7 +551,7 @@ public class ThinResultSet implements ResultSet {
   @Override
   @Deprecated
   public BigDecimal getBigDecimal( String columnName, int arg1 ) throws SQLException {
-    return getBigDecimal( rowMeta.indexOfValue( columnName ) );
+    return getBigDecimal( rowMeta.indexOfValue( columnName ) + 1 );
   }
 
   @Override
@@ -570,6 +576,7 @@ public class ThinResultSet implements ResultSet {
 
   @Override
   public boolean getBoolean( int index ) throws SQLException {
+    validateIndex( index );
     try {
       Boolean b = rowMeta.getBoolean( currentRow, index - 1 );
       if ( b == null ) {
@@ -585,7 +592,7 @@ public class ThinResultSet implements ResultSet {
 
   @Override
   public boolean getBoolean( String columnName ) throws SQLException {
-    return getBoolean( rowMeta.indexOfValue( columnName ) );
+    return getBoolean( rowMeta.indexOfValue( columnName ) + 1 );
   }
 
   @Override
@@ -596,11 +603,12 @@ public class ThinResultSet implements ResultSet {
 
   @Override
   public byte getByte( String columnName ) throws SQLException {
-    return getByte( rowMeta.indexOfValue( columnName ) );
+    return getByte( rowMeta.indexOfValue( columnName ) + 1 );
   }
 
   @Override
   public byte[] getBytes( int index ) throws SQLException {
+    validateIndex( index );
     try {
       byte[] binary = rowMeta.getBinary( currentRow, index - 1 );
       if ( binary == null ) {
@@ -616,7 +624,7 @@ public class ThinResultSet implements ResultSet {
 
   @Override
   public byte[] getBytes( String columnName ) throws SQLException {
-    return getBytes( rowMeta.indexOfValue( columnName ) );
+    return getBytes( rowMeta.indexOfValue( columnName ) + 1 );
   }
 
   @Override
@@ -659,11 +667,12 @@ public class ThinResultSet implements ResultSet {
 
   @Override
   public int getInt( String columnName ) throws SQLException {
-    return getInt( rowMeta.indexOfValue( columnName ) );
+    return getInt( rowMeta.indexOfValue( columnName ) + 1 );
   }
 
   @Override
   public long getLong( int index ) throws SQLException {
+    validateIndex( index );
     try {
       Long d = rowMeta.getInteger( currentRow, index - 1 );
       if ( d == null ) {
@@ -679,7 +688,7 @@ public class ThinResultSet implements ResultSet {
 
   @Override
   public long getLong( String columnName ) throws SQLException {
-    return getLong( rowMeta.indexOfValue( columnName ) );
+    return getLong( rowMeta.indexOfValue( columnName ) + 1 );
   }
 
   @Override
@@ -714,12 +723,13 @@ public class ThinResultSet implements ResultSet {
 
   @Override
   public Object getObject( int index ) throws SQLException {
+    validateIndex( index );
     return currentRow[index - 1];
   }
 
   @Override
   public Object getObject( String columnName ) throws SQLException {
-    return getObject( rowMeta.indexOfValue( columnName ) );
+    return getObject( rowMeta.indexOfValue( columnName ) + 1 );
   }
 
   @Override
@@ -770,11 +780,12 @@ public class ThinResultSet implements ResultSet {
 
   @Override
   public short getShort( String columnName ) throws SQLException {
-    return getShort( rowMeta.indexOfValue( columnName ) );
+    return getShort( rowMeta.indexOfValue( columnName ) + 1 );
   }
 
   @Override
   public String getString( int index ) throws SQLException {
+    validateIndex( index );
     try {
       String string = rowMeta.getString( currentRow, index - 1 );
       if ( string == null ) {
@@ -790,7 +801,7 @@ public class ThinResultSet implements ResultSet {
 
   @Override
   public String getString( String columnName ) throws SQLException {
-    return getString( rowMeta.indexOfValue( columnName ) );
+    return getString( rowMeta.indexOfValue( columnName ) + 1 );
   }
 
   @Override
@@ -824,7 +835,7 @@ public class ThinResultSet implements ResultSet {
 
   @Override
   public Timestamp getTimestamp( String columnName ) throws SQLException {
-    return getTimestamp( rowMeta.indexOfValue( columnName ) );
+    return getTimestamp( rowMeta.indexOfValue( columnName ) + 1 );
   }
 
   @Override
@@ -1327,5 +1338,11 @@ public class ThinResultSet implements ResultSet {
 
   public <T> T getObject( String columnLabel, Class<T> type ) throws SQLException {
     throw new SQLException( "Method not supported" );
+  }
+
+  private void validateIndex( int index ) throws SQLException {
+    if ( index < 1 || rowMeta.size() < index ) {
+      throw new SQLException( "Invalid column reference." );
+    }
   }
 }

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/ThinResultSetTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/ThinResultSetTest.java
@@ -1,0 +1,191 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.dataservice.jdbc;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaNumber;
+import org.pentaho.di.core.row.value.ValueMetaString;
+
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Date;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class ThinResultSetTest  {
+
+  public static final String INVALID_COLUMN_REFERENCE = "Invalid column reference.";
+  RowMeta rowMeta = new RowMeta();
+  ThinResultSet thinResultSet;
+
+  @Before
+  public void setUp() throws Exception {
+    thinResultSet = new ThinResultSet();
+    thinResultSet.rowMeta = rowMeta;
+  }
+
+  @Test public void testGetDate() throws Exception {
+    ValueMetaDate valueMetaDate = new ValueMetaDate( "foo" );
+    Date date = new Date();
+    thinResultSet.currentRow = new Object[] { new Date() };
+    rowMeta.addValueMeta( valueMetaDate );
+    assertThat( thinResultSet.getDate( "foo" ), equalTo( date ) );
+  }
+
+  @Test public void testGetDouble() throws Exception {
+    thinResultSet.currentRow = new Object[] { 1.1, "foo" };
+    rowMeta.addValueMeta( new ValueMetaNumber( "number" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    assertThat( thinResultSet.getDouble( "number" ), equalTo( 1.1 ) );
+  }
+
+  @Test public void testGetBigDecimal() throws Exception {
+    thinResultSet.currentRow = new Object[] { 1.1, "foo" };
+    rowMeta.addValueMeta( new ValueMetaNumber( "number" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    assertThat( thinResultSet.getBigDecimal( "number" ).doubleValue(), equalTo( 1.1 ) );
+  }
+
+  @Test public void testGetByte() throws Exception {
+    byte b = 'a';
+    thinResultSet.currentRow = new Object[] { new Byte( b ).longValue(), "foo" };
+    rowMeta.addValueMeta( new ValueMetaInteger( "byte" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    assertThat( thinResultSet.getByte( "byte" ), equalTo( b ) );
+  }
+
+  @Test public void testGetBytes() throws Exception {
+    thinResultSet.currentRow = new Object[] { "b", "foo" };
+    rowMeta.addValueMeta( new ValueMetaString( "bytes" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    assertThat( thinResultSet.getBytes( "bytes" ), equalTo( new byte[] { 'b' } ) );
+
+  }
+
+  @Test public void testGetFloat() throws Exception {
+    thinResultSet.currentRow = new Object[] { 1.1, "foo" };
+    rowMeta.addValueMeta( new ValueMetaNumber( "col" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    assertThat( thinResultSet.getFloat( "col" ), equalTo( 1.1f ) );
+  }
+
+  @Test public void testGetInt() throws Exception {
+    thinResultSet.currentRow = new Object[] { 1l, "foo" };
+    rowMeta.addValueMeta( new ValueMetaInteger( "col" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    assertThat( thinResultSet.getInt( "col" ), equalTo( 1 ) );
+
+  }
+
+  @Test public void testGetLong() throws Exception {
+    thinResultSet.currentRow = new Object[] { 1l, "foo" };
+    rowMeta.addValueMeta( new ValueMetaInteger( "col" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    assertThat( thinResultSet.getLong( "col" ), equalTo( 1l ) );
+  }
+
+  @Test public void testGetShort() throws Exception {
+    thinResultSet.currentRow = new Object[] { 1l, "foo" };
+    rowMeta.addValueMeta( new ValueMetaInteger( "col" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    short s = 1;
+    assertThat( thinResultSet.getShort( "col" ), equalTo( s ) );
+
+  }
+
+  @Test public void testGetString() throws Exception {
+    thinResultSet.currentRow = new Object[] { "a string", "foo" };
+    rowMeta.addValueMeta( new ValueMetaString( "col" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    assertThat( thinResultSet.getString( "col" ), equalTo( "a string" ) );
+  }
+
+  @Test public void testGetTimestamp() throws Exception {
+    thinResultSet.currentRow = new Object[] { "2010/01/01 10:10:10.000", "foo" };
+    rowMeta.addValueMeta( new ValueMetaString( "col" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    assertThat( thinResultSet.getTimestamp( "col" ), equalTo( new Timestamp( 1262358610000l ) ) );
+  }
+
+  @Test
+  public void testGetColumnNotPresentDouble() throws Exception {
+    thinResultSet.currentRow = new Object[] { 1.1, "foo" };
+    rowMeta.addValueMeta( new ValueMetaNumber( "number" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    try {
+      thinResultSet.getDouble( "nonesuch" );
+    } catch ( SQLException e ) {
+      assertThat( e.getMessage(), equalTo( INVALID_COLUMN_REFERENCE ) );
+      return;
+    }
+    fail();
+  }
+
+  @Test
+  public void testGetColumnNotPresentString() throws Exception {
+    thinResultSet.currentRow = new Object[] { 1.1, "foo" };
+    rowMeta.addValueMeta( new ValueMetaNumber( "number" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    try {
+      thinResultSet.getString( "nonesuch" );
+    } catch ( SQLException e ) {
+      assertThat( e.getMessage(), equalTo( INVALID_COLUMN_REFERENCE ) );
+      return;
+    }
+    fail();
+  }
+
+  @Test
+  public void testGetColumnIndexNotPresentString() throws Exception {
+    thinResultSet.currentRow = new Object[] { 1.1, "foo" };
+    rowMeta.addValueMeta( new ValueMetaNumber( "number" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    try {
+      thinResultSet.getString( 4 );
+    } catch ( SQLException e ) {
+      assertThat( e.getMessage(), equalTo( INVALID_COLUMN_REFERENCE ) );
+      return;
+    }
+    fail();
+  }
+
+  @Test
+  public void testGetColumnNotPresentObject() throws Exception {
+    thinResultSet.currentRow = new Object[] { 1.1, "foo" };
+    rowMeta.addValueMeta( new ValueMetaNumber( "number" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    try {
+      thinResultSet.getObject( "nonesuch" );
+    } catch ( SQLException e ) {
+      assertThat( e.getMessage(), equalTo( INVALID_COLUMN_REFERENCE ) );
+      return;
+    }
+    fail();
+  }
+}


### PR DESCRIPTION
Formerly shifted index by 1, since the RowMeta.indexOfValue is 0 based
and the .getXXX( int ) assumes 1 based.

@bmorrise @hudak 
