### PR TITLE
JDBC RemoteClient refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/pdi-dataservice-client/pom.xml
+++ b/pdi-dataservice-client/pom.xml
@@ -84,6 +84,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>java-hamcrest</artifactId>
+      <version>2.0.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
       <version>${mockito.version}</version>
@@ -93,12 +99,6 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>java-hamcrest</artifactId>
-      <version>2.0.0.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/client/DataServiceClientService.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/client/DataServiceClientService.java
@@ -31,8 +31,8 @@ import java.sql.SQLException;
 import java.util.List;
 
 public interface DataServiceClientService {
-  public void setMetaStore( IMetaStore metaStore );
-  public void setRepository( Repository repository );
-  public DataInputStream query( String sql, final int maxRows ) throws SQLException;
-  public List<ThinServiceInformation> getServiceInformation() throws SQLException;
+  void setMetaStore( IMetaStore metaStore );
+  void setRepository( Repository repository );
+  DataInputStream query( String sql, int maxRows ) throws SQLException;
+  List<ThinServiceInformation> getServiceInformation() throws SQLException;
 }

--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/RemoteClient.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/RemoteClient.java
@@ -1,0 +1,161 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.dataservice.jdbc;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Lists;
+import org.apache.commons.httpclient.Header;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.xml.XMLHandler;
+import org.pentaho.di.repository.Repository;
+import org.pentaho.di.trans.dataservice.client.DataServiceClientService;
+import org.pentaho.metastore.api.IMetaStore;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * @author nhudak
+ */
+class RemoteClient implements DataServiceClientService {
+  private final ThinConnection connection;
+  private final HttpClient client;
+  private DocumentBuilderFactory docBuilderFactory;
+
+  RemoteClient( ThinConnection connection, HttpClient client ) {
+    this.connection = connection;
+    this.client = client;
+  }
+
+  @Override public DataInputStream query( String sql, int maxRows ) throws SQLException {
+    try {
+      String url = connection.constructUrl( "/sql" );
+      PostMethod method = new PostMethod( url );
+      method.setDoAuthentication( true );
+
+      method.addRequestHeader( new Header( "SQL", CharMatcher.anyOf( "\n\r" ).collapseFrom( sql, ' ' ) ) );
+      method.addRequestHeader( new Header( "MaxRows", Integer.toString( maxRows ) ) );
+
+      method.getParams().setParameter( "http.socket.timeout", 0 );
+
+      return new DataInputStream( execMethod( method ).getResponseBodyAsStream() );
+    } catch ( Exception e ) {
+      throw serverException( e );
+    }
+  }
+
+  @Override public List<ThinServiceInformation> getServiceInformation() throws SQLException {
+    List<ThinServiceInformation> services = Lists.newArrayList();
+
+    try {
+      String result = execService( "/listServices" );
+      Document doc = XMLHandler.loadXMLString( createDocumentBuilder(), result );
+      Node servicesNode = XMLHandler.getSubNode( doc, "services" );
+      List<Node> serviceNodes = XMLHandler.getNodes( servicesNode, "service" );
+
+      for ( Node serviceNode : serviceNodes ) {
+        String name = XMLHandler.getTagValue( serviceNode, "name" );
+        Node rowMetaNode = XMLHandler.getSubNode( serviceNode, RowMeta.XML_META_TAG );
+        RowMetaInterface serviceFields = new RowMeta( rowMetaNode );
+        ThinServiceInformation service = new ThinServiceInformation( name, serviceFields );
+        services.add( service );
+      }
+    } catch ( Exception e ) {
+      throw serverException( e );
+    }
+
+    return services;
+  }
+
+  private DocumentBuilder createDocumentBuilder() throws ParserConfigurationException {
+    if ( docBuilderFactory == null ) {
+      docBuilderFactory = DocumentBuilderFactory.newInstance();
+    }
+    return docBuilderFactory.newDocumentBuilder();
+  }
+
+  String execService( String serviceAndArguments ) throws SQLException {
+    try {
+      String urlString = connection.constructUrl( serviceAndArguments );
+      HttpMethod method = new GetMethod( urlString );
+
+      try {
+        return execMethod( method ).getResponseBodyAsString();
+      } finally {
+        method.releaseConnection();
+      }
+
+    } catch ( Exception e ) {
+      throw serverException( e );
+    }
+  }
+
+  HttpMethod execMethod( HttpMethod method ) throws SQLException {
+    try {
+      int result = client.executeMethod( method );
+
+      if ( result == 500 ) {
+        throw new SQLException( "There was an error reading data from the server." );
+      }
+
+      if ( result == 401 ) {
+        throw new SQLException(
+          "Nice try-but we couldn't log you in. Check your username and password and try again." );
+      }
+
+      if ( result != 200 ) {
+        throw new SQLException( method.getResponseBodyAsString() );
+      }
+    } catch ( IOException e ) {
+      throw new SQLException(
+        "You don't seem to be getting a connection to the server. Check the host and port you're using and make sure the sever is up and running." );
+    }
+    return method;
+  }
+
+  private static SQLException serverException( Exception e ) throws SQLException {
+    Throwables.propagateIfPossible( e, SQLException.class );
+    throw new SQLException( "Error connecting to server", e );
+  }
+
+  @Deprecated
+  public void setRepository( Repository repository ) {
+  }
+
+  @Deprecated
+  public void setMetaStore( IMetaStore metaStore ) {
+  }
+}

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/MockDataInput.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/MockDataInput.java
@@ -1,0 +1,65 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.dataservice.jdbc;
+
+import org.pentaho.di.core.exception.KettleFileException;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.value.ValueMetaString;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * @author nhudak
+ */
+class MockDataInput extends DataOutputStream {
+  public MockDataInput() {
+    super( new ByteArrayOutputStream() );
+  }
+
+  public static MockDataInput dual() throws IOException, KettleFileException {
+    MockDataInput dataOutput = new MockDataInput();
+    dataOutput.writeUTF( "dual" );
+    dataOutput.writeUTF( "" );
+    dataOutput.writeUTF( "" );
+    dataOutput.writeUTF( "" );
+    dataOutput.writeUTF( "" );
+
+    RowMeta rowMeta = new RowMeta();
+    rowMeta.addValueMeta( new ValueMetaString( "DUMMY" ) );
+    rowMeta.writeMeta( dataOutput );
+    rowMeta.writeData( dataOutput, new Object[] { "X" } );
+    return dataOutput;
+  }
+
+  public byte[] getBuffer() {
+    return ( (ByteArrayOutputStream) out ).toByteArray();
+  }
+
+  public DataInputStream toDataInputStream() {
+    return new DataInputStream( new ByteArrayInputStream( getBuffer() ) );
+  }
+}

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/RemoteClientTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/RemoteClientTest.java
@@ -1,0 +1,149 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.dataservice.jdbc;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.io.Resources;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.sql.SQLException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author nhudak
+ */
+@RunWith( MockitoJUnitRunner.class )
+public class RemoteClientTest {
+
+  @Mock ThinConnection connection;
+  @Mock HttpClient httpClient;
+  @Mock HttpMethod execMethod;
+  @Captor ArgumentCaptor<HttpMethod> httpMethodCaptor;
+  RemoteClient remoteClient;
+
+  @Before
+  public void setUp() throws Exception {
+    remoteClient = new RemoteClient( connection, httpClient ) {
+      // Intercept execMethod so we can inject our mock response streams
+      @Override protected HttpMethod execMethod( HttpMethod method ) throws SQLException {
+        super.execMethod( method );
+        return execMethod;
+      }
+    };
+    when( connection.constructUrl( anyString() ) ).then( new Answer<String>() {
+      @Override public String answer( InvocationOnMock invocation ) throws Throwable {
+        return "http://localhost:9080/pentaho-di/kettle" + invocation.getArguments()[0];
+      }
+    } );
+  }
+
+  @Test
+  public void testQuery() throws Exception {
+    String url = "http://localhost:9080/pentaho-di/kettle/sql";
+    String sql = "SELECT * FROM myService\nWHERE id = 3";
+    int maxRows = 200;
+
+    when( httpClient.executeMethod( isA( PostMethod.class ) ) ).thenReturn( 200 );
+
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    new DataOutputStream( outputStream ).writeUTF( "Query Response" );
+
+    when( execMethod.getResponseBodyAsStream() ).thenReturn( new ByteArrayInputStream( outputStream.toByteArray() ) );
+
+    DataInputStream queryResponse = remoteClient.query( sql, maxRows );
+
+    verify( httpClient ).executeMethod( httpMethodCaptor.capture() );
+    HttpMethod httpMethod = httpMethodCaptor.getValue();
+    assertThat( httpMethod.getURI().toString(), equalTo( url ) );
+    assertThat( httpMethod.getRequestHeader( "SQL" ).getValue(), equalTo( "SELECT * FROM myService WHERE id = 3" ) );
+    assertThat( httpMethod.getRequestHeader( "MaxRows" ).getValue(), equalTo( "200" ) );
+
+    assertThat( queryResponse.readUTF(), equalTo( "Query Response" ) );
+  }
+
+  @Test
+  public void testGetServiceInformation() throws Exception {
+    String url = "http://localhost:9080/pentaho-di/kettle/listServices";
+    String xml = Resources.toString( ClassLoader.getSystemResource( "jdbc/listServices.xml" ), Charsets.UTF_8 );
+    when( httpClient.executeMethod( isA( GetMethod.class ) ) ).thenReturn( 200 );
+    when( execMethod.getResponseBodyAsString() ).thenReturn( xml );
+
+    ThinServiceInformation serviceInformation = Iterables.getOnlyElement( remoteClient.getServiceInformation() );
+
+    verify( httpClient ).executeMethod( httpMethodCaptor.capture() );
+    assertThat( httpMethodCaptor.getValue().getURI().toString(), equalTo( url ) );
+
+    assertThat( serviceInformation.getName(), is( "sequence" ) );
+    assertThat( serviceInformation.getServiceFields().getFieldNames(), arrayContaining( "valuename" ) );
+  }
+
+  @Test
+  public void testExecMethod() throws Exception {
+    ImmutableList<Integer> statusCodes = ImmutableList.of( 500, 401, 404 );
+    when( execMethod.getResponseBodyAsString() ).thenReturn( "kettle status" );
+
+    for ( Integer statusCode : statusCodes ) {
+      when( httpClient.executeMethod( any( HttpMethod.class ) ) ).thenReturn( statusCode );
+      try {
+        remoteClient.execMethod( execMethod );
+        fail( "Expected an exception from response code" + statusCode );
+      } catch ( SQLException e ) {
+        assertThat( statusCode + " exception", e.getMessage(), not( emptyOrNullString() ) );
+      }
+    }
+
+    when( httpClient.executeMethod( any( HttpMethod.class ) ) ).thenReturn( 200 );
+    assertThat( remoteClient.execService( "/status" ), equalTo( "kettle status" ) );
+  }
+
+}

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/ThinConnectionTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/ThinConnectionTest.java
@@ -1,16 +1,79 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
 package org.pentaho.di.trans.dataservice.jdbc;
 
+import org.apache.commons.httpclient.Credentials;
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.UsernamePasswordCredentials;
+import org.apache.commons.httpclient.auth.AuthScope;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.pentaho.di.cluster.SlaveConnectionManager;
+import org.pentaho.di.trans.dataservice.client.DataServiceClientService;
 
-import static org.junit.Assert.*;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Created by bmorrise on 9/28/15.
  */
+@RunWith( MockitoJUnitRunner.class )
 public class ThinConnectionTest {
 
+  ThinConnection connection;
+  Properties properties;
+
+  @Mock( answer = Answers.RETURNS_DEEP_STUBS ) SlaveConnectionManager connectionManager;
+  @Mock DataServiceClientService clientService;
+
+  @Before
+  public void setUp() throws Exception {
+    properties = new Properties();
+    properties.setProperty( "user", "username" );
+    properties.setProperty( "password", "password" );
+
+    connection = new ThinConnection.Builder( connectionManager ).build( clientService );
+  }
+
   @Test
-  public void testThinConnection() throws Exception {
+  public void testBuilder() throws Exception {
     String host = "localhost";
     String port = "9080";
     String webAppName = "pentaho-di";
@@ -27,13 +90,26 @@ public class ThinConnectionTest {
         "jdbc:pdi://" + host + ":" + port + "/kettle?webappname=" + webAppName + "&proxyhostname=" + proxyHostName
             + "&proxyport=" + proxyPort + "&nonproxyhosts=" + nonProxyHosts + "&debugtrans=" + debugTrans + "&debuglog="
             + debugLog + "&secure=" + secure + "&local=" + local;
-    String username = "username";
-    String password = "password";
 
-    ThinConnection thinConnection = new ThinConnection( url, username, password );
+    ThinConnection thinConnection = new ThinConnection.Builder( connectionManager )
+      .parseUrl( url )
+      .readProperties( properties )
+      .build();
 
+    HttpClient httpClient = connectionManager.createHttpClient();
+    ArgumentCaptor<Credentials> credentialsArgumentCaptor = ArgumentCaptor.forClass( Credentials.class );
+
+    verify( httpClient.getParams() ).setAuthenticationPreemptive( true );
+    verify( httpClient.getState() ).setCredentials( eq( AuthScope.ANY ), credentialsArgumentCaptor.capture() );
+    verify( httpClient.getHostConfiguration() ).setProxy( proxyHostName, 9081 );
+    assertThat( credentialsArgumentCaptor.getValue(),
+      equalTo( (Credentials) new UsernamePasswordCredentials( "username", "password" ) ) );
+    assertThat( thinConnection.getClientService(), instanceOf( RemoteClient.class ) );
+
+    assertEquals( url, thinConnection.getUrl() );
     assertEquals( host, thinConnection.getHostname() );
     assertEquals( port, thinConnection.getPort() );
+    assertEquals( "username", thinConnection.getUsername() );
     assertEquals( webAppName, thinConnection.getWebAppName() );
     assertEquals( proxyHostName, thinConnection.getProxyHostname() );
     assertEquals( proxyPort, thinConnection.getProxyPort() );
@@ -44,4 +120,19 @@ public class ThinConnectionTest {
     assertEquals( false, thinConnection.isLocal() );
   }
 
+  @Test
+  public void testValid() throws Exception {
+    when( clientService.query( eq( "SELECT *" ), anyInt() ) )
+      .thenThrow( new SQLException( "Expected exception" ) )
+      .thenReturn( MockDataInput.dual().toDataInputStream() );
+
+    assertThat( connection.isValid( 0 ), is( false ) );
+    assertThat( connection.getWarnings().getMessage(), containsString( "Expected exception" ) );
+
+    connection.clearWarnings();
+    if ( !connection.isValid( 0 ) ) {
+      throw new AssertionError( connection.getWarnings() );
+    }
+    assertThat( connection.getWarnings(), nullValue() );
+  }
 }

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/ThinResultSetTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/ThinResultSetTest.java
@@ -37,6 +37,7 @@ import java.util.Date;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 public class ThinResultSetTest  {
 
@@ -46,7 +47,7 @@ public class ThinResultSetTest  {
 
   @Before
   public void setUp() throws Exception {
-    thinResultSet = new ThinResultSet();
+    thinResultSet = new ThinResultSet( mock( ThinStatement.class ) );
     thinResultSet.rowMeta = rowMeta;
   }
 

--- a/pdi-dataservice-client/src/test/resources/jdbc/listServices.xml
+++ b/pdi-dataservice-client/src/test/resources/jdbc/listServices.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<services>
+    <service>
+        <name>sequence</name>
+        <row-meta><value-meta><type>Integer</type>
+            <storagetype>normal</storagetype>
+            <name>valuename</name>
+            <length>-1</length>
+            <precision>-1</precision>
+            <origin>Add sequence</origin>
+            <comments/>
+            <conversion_Mask>&#x23;&#x3b;-&#x23;</conversion_Mask>
+            <decimal_symbol>.</decimal_symbol>
+            <grouping_symbol>,</grouping_symbol>
+            <currency_symbol/>
+            <trim_type>none</trim_type>
+            <case_insensitive>N</case_insensitive>
+            <sort_descending>N</sort_descending>
+            <output_padding>N</output_padding>
+            <date_format_lenient>N</date_format_lenient>
+            <date_format_locale>en_US</date_format_locale>
+            <date_format_timezone>Etc&#x2f;UTC</date_format_timezone>
+            <lenient_string_to_number>N</lenient_string_to_number>
+        </value-meta></row-meta>
+    </service>
+</services>

--- a/pom.xml
+++ b/pom.xml
@@ -24,4 +24,26 @@
     <plugin.org.apache.maven.plugins.maven-assembly-plugin.version>2.4</plugin.org.apache.maven.plugins.maven-assembly-plugin.version>
     <junit.version>4.4</junit.version>
   </properties>
+
+  <!-- this is for bootstrapping only; you should really just add this to your settings.xml -->
+  <repositories>
+    <repository>
+      <id>pentaho.resolve.repo</id>
+      <name>Pentaho Group Resolve Repository</name>
+      <url>http://nexus.pentaho.org/content/groups/omni/</url>
+      <releases>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </releases>
+      <snapshots>
+        <updatePolicy>always</updatePolicy>
+        <checksumPolicy>fail</checksumPolicy>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>repo.pentaho.org</id>
+      <name>repo.pentaho.org</name>
+      <url>http://repository.pentaho.org/artifactory/pentaho</url>
+    </repository>
+  </repositories>
 </project>


### PR DESCRIPTION
Consolidate all http connections to one class
Remove connection logic from class constructors
Make ResultSet/Statement classes agnostic to remote/local connections

[![Build Status](https://travis-ci.org/hudak/pdi-dataservice-plugin.svg?branch=httpRefactor)](https://travis-ci.org/hudak/pdi-dataservice-plugin)
