### PR TITLE
[BACKLOG-5530]Fix LifecycleListener

### DIFF
--- a/pdi-dataservice-client/pom.xml
+++ b/pdi-dataservice-client/pom.xml
@@ -58,6 +58,10 @@
       </roles>
     </developer>
   </developers>
+  <properties>
+    <swt.version>4.3.2</swt.version>
+    <jface.version>3.3.0-I20070606-0010</jface.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>pentaho-kettle</groupId>
@@ -75,6 +79,24 @@
       <groupId>pentaho-kettle</groupId>
       <artifactId>kettle-ui-swt</artifactId>
       <version>${dependency.pentaho-kettle.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.swt</groupId>
+      <artifactId>swt-linux-x86_64</artifactId>
+      <version>${swt.version}</version>
+      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse</groupId>
+      <artifactId>jface</artifactId>
+      <version>${jface.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Activate localClient only when lifecycle listener has started
[![Build Status](https://travis-ci.org/hudak/pdi-dataservice-plugin.svg?branch=BACKLOG-5530)](https://travis-ci.org/hudak/pdi-dataservice-plugin)

http://jira.pentaho.com/browse/BACKLOG-5530
