### PR TITLE
[BACKLOG-5502]ThinPreparedStatement is safe

### DIFF
--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/ThinPreparedStatement.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/ThinPreparedStatement.java
@@ -69,7 +69,11 @@ public class ThinPreparedStatement extends ThinStatement implements PreparedStat
   protected Object[] paramData;
 
   public ThinPreparedStatement( ThinConnection connection, String sql ) throws SQLException {
-    super( connection );
+    this( connection, sql, new ThinResultFactory() );
+  }
+
+  public ThinPreparedStatement( ThinConnection connection, String sql, ThinResultFactory resultFactory ) throws SQLException {
+    super( connection, resultFactory );
     this.sql = sql;
 
     analyzeSql();
@@ -187,9 +191,10 @@ public class ThinPreparedStatement extends ThinStatement implements PreparedStat
     throw new SQLFeatureNotSupportedException( "Update operations are not supported" );
   }
 
-  @Override @NotSupported
+  @Override
   public ResultSetMetaData getMetaData() throws SQLException {
-    throw new SQLFeatureNotSupportedException( "Prepared statement meta data is not available" );
+    ResultSet resultSet = getResultSet();
+    return resultSet == null ? null : resultSet.getMetaData();
   }
 
   @Override

--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/ThinStatement.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/ThinStatement.java
@@ -35,15 +35,15 @@ public class ThinStatement extends ThinBase implements Statement {
 
   protected final ThinConnection connection;
   private final ThinResultFactory resultFactory;
-  protected ThinResultSet resultSet;
+  private ThinResultSet resultSet;
 
-  protected int maxRows;
+  protected int maxRows = -1;
 
   public ThinStatement( ThinConnection connection ) {
     this( connection, new ThinResultFactory() );
   }
 
-  public ThinStatement( ThinConnection connection, ThinResultFactory resultFactory ) {
+  protected ThinStatement( ThinConnection connection, ThinResultFactory resultFactory ) {
     this.connection = connection;
     this.resultFactory = resultFactory;
   }

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/MockDataInput.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/MockDataInput.java
@@ -51,7 +51,7 @@ class MockDataInput extends DataOutputStream {
     RowMeta rowMeta = new RowMeta();
     rowMeta.addValueMeta( new ValueMetaString( "DUMMY" ) );
     rowMeta.writeMeta( dataOutput );
-    rowMeta.writeData( dataOutput, new Object[] { "X" } );
+    rowMeta.writeData( dataOutput, new Object[] { "x" } );
     return dataOutput;
   }
 

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/ThinResultFactoryTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/ThinResultFactoryTest.java
@@ -1,0 +1,77 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.trans.dataservice.jdbc;
+
+import com.google.common.base.Throwables;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+import static org.hamcrest.Matchers.anything;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author nhudak
+ */
+
+@RunWith( org.mockito.runners.MockitoJUnitRunner.class )
+public class ThinResultFactoryTest {
+
+  @InjectMocks ThinResultFactory factory;
+
+  @Test
+  public void testLoadResultSet() throws Exception {
+    DataInputStream inputStream = MockDataInput.dual().toDataInputStream();
+
+    ThinResultSet resultSet = factory.loadResultSet( inputStream );
+    ResultSetMetaData metaData = resultSet.getMetaData();
+
+    assertThat( metaData.getTableName( 1 ), is( "dual" ) );
+    assertThat( metaData.getColumnLabel( 1 ), is( "DUMMY" ) );
+    assertThat( resultSet.next(), is( true ) );
+    assertThat( resultSet.getString( 1 ), is( "x" ) );
+  }
+
+  @Test
+  public void testLoadResultSetFailure() throws Exception {
+    InputStream inputStream = mock( InputStream.class );
+    IOException expected = new IOException();
+    when( inputStream.read() ).thenThrow( expected );
+
+    try {
+      assertThat( factory.loadHeader( new DataInputStream( inputStream ) ), not( anything() ) );
+    } catch ( SQLException e ) {
+      assertThat( Throwables.getRootCause( e ), is( (Throwable) expected ) );
+    }
+  }
+}


### PR DESCRIPTION
Per JDBC specification, PreparedStatement.getMetaData() should return null if not available, not throw an exception.
