### PR TITLE
[BACKLOG-5020] The dataservice client zip should be easily retrievable from the dataservice edit dialog

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>pdi-dataservice-client-plugin-parent</artifactId>
     <version>6.1-SNAPSHOT</version>
   </parent>
-  <artifactId>pdi-dataservice-client-plugin-assembly</artifactId>
+  <artifactId>pdi-dataservice-driver-bundle</artifactId>
   <version>6.1-SNAPSHOT</version>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Rename pdi-dataservice-client-plugin-assembly artifact to
pdi-dataservice-client-plugin-bundle
