### PR TITLE
[PDI-14635]  Appending a / to the data service url

### DIFF
--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/RemoteClient.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/RemoteClient.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -61,6 +61,7 @@ class RemoteClient implements DataServiceClientService {
   private final ThinConnection connection;
   private final HttpClient client;
   private DocumentBuilderFactory docBuilderFactory;
+  private static final String SERVICE_PATH = "/sql/";
 
   RemoteClient( ThinConnection connection, HttpClient client ) {
     this.connection = connection;
@@ -69,7 +70,7 @@ class RemoteClient implements DataServiceClientService {
 
   @Override public DataInputStream query( String sql, int maxRows ) throws SQLException {
     try {
-      String url = connection.constructUrl( "/sql" );
+      String url = connection.constructUrl( SERVICE_PATH );
       PostMethod method = new PostMethod( url );
       method.setDoAuthentication( true );
 

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/RemoteClientTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/RemoteClientTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -109,7 +109,7 @@ public class RemoteClientTest {
     verify( httpClient ).executeMethod( httpMethodCaptor.capture() );
     PostMethod httpMethod = (PostMethod) httpMethodCaptor.getValue();
 
-    assertThat( httpMethod.getURI().toString(), equalTo( "http://localhost:9080/pentaho-di/kettle/sql" ) );
+    assertThat( httpMethod.getURI().toString(), equalTo( "http://localhost:9080/pentaho-di/kettle/sql/" ) );
     assertThat( httpMethod.getRequestHeader( "SQL" ).getValue(), equalTo( "SELECT * FROM myService WHERE id = 3" ) );
     assertThat( httpMethod.getRequestHeader( "MaxRows" ).getValue(), equalTo( "200" ) );
     assertThat( httpMethod.getParameter( "SQL" ).getValue(), equalTo( "SELECT * FROM myService WHERE id = 3" ) );
@@ -142,7 +142,7 @@ public class RemoteClientTest {
     verify( httpClient ).executeMethod( httpMethodCaptor.capture() );
     PostMethod httpMethod = (PostMethod) httpMethodCaptor.getValue();
 
-    assertThat( httpMethod.getURI().toString(), equalTo( "http://localhost:9080/pentaho-di/kettle/sql" ) );
+    assertThat( httpMethod.getURI().toString(), equalTo( "http://localhost:9080/pentaho-di/kettle/sql/" ) );
     assertThat( httpMethod.getRequestHeader( "SQL" ), is( nullValue() ) );
     assertThat( httpMethod.getRequestHeader( "MaxRows" ), is( nullValue() ) );
     assertThat( httpMethod.getParameter( "SQL" ).getValue(),


### PR DESCRIPTION
E.g. http://localhost:9080/pentaho-di/kettle/sql/

This prevents Jetty from redirecting to /sql/,
in the process converting a POST request to
to a GET.

Jetty reference:
http://download.eclipse.org/jetty/stable-9/apidocs/org/eclipse/jetty/server/handler/ContextHandler.html#setAllowNullPathInfo-boolean-
