### PR TITLE
[BACKLOG-6689] Error thrown when querying numeric null field.

### DIFF
--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/BaseResultSet.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/BaseResultSet.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -125,11 +125,11 @@ public abstract class BaseResultSet extends ThinBase implements ResultSet {
 
   @Override
   public double getDouble( int index ) throws SQLException {
-    return getValue( index, new ValueRetriever<Double>() {
+    return getNonNullableValue( index, new ValueRetriever<Double>() {
       @Override public Double value( int index ) throws Exception {
         return rowMeta.getNumber( currentRow, index );
       }
-    } );
+    }, 0.0 );
   }
 
   @Override
@@ -205,11 +205,11 @@ public abstract class BaseResultSet extends ThinBase implements ResultSet {
 
   @Override
   public boolean getBoolean( int index ) throws SQLException {
-    return getValue( index, new ValueRetriever<Boolean>() {
+    return getNonNullableValue( index, new ValueRetriever<Boolean>() {
       @Override public Boolean value( int index ) throws Exception {
         return rowMeta.getBoolean( currentRow, index );
       }
-    } );
+    }, false );
   }
 
   @Override
@@ -284,11 +284,11 @@ public abstract class BaseResultSet extends ThinBase implements ResultSet {
 
   @Override
   public long getLong( int index ) throws SQLException {
-    return getValue( index, new ValueRetriever<Long>() {
+    return getNonNullableValue( index, new ValueRetriever<Long>() {
       @Override public Long value( int index ) throws Exception {
         return rowMeta.getInteger( currentRow, index );
       }
-    } );
+    }, 0l );
   }
 
   @Override
@@ -915,6 +915,20 @@ public abstract class BaseResultSet extends ThinBase implements ResultSet {
       Throwables.propagateIfPossible( e, SQLException.class );
       throw new SQLException( e );
     }
+  }
+
+  /**
+   * Retrieves the value of a non-nullable column.  If the column has a SQL NULL value,
+   * return the specified defaultValue instead.
+   * Methods which return primitive values (getLong, getInt, getBoolean, etc.) cannot
+   * return null.  The client can determine whether the value was SQL NULL or actually
+   * equal to defaultValue by using the .wasNull() method.
+   * @throws SQLException
+   */
+  private <T> T getNonNullableValue( int index, ValueRetriever<T> valueRetriever, T defaultValue )
+          throws SQLException {
+    T value = getValue( index, valueRetriever );
+    return value == null ? defaultValue : value;
   }
 
   @Override

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/BaseResultSetTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/BaseResultSetTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2015 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -120,83 +120,116 @@ public abstract class BaseResultSetTest extends JDBCTestBase<BaseResultSet> {
   }
 
   @Test public void testGetDouble() throws Exception {
-    setNextRow( new Object[] { 1.1, "foo" } );
+    setNextRow( new Object[] { 1.1, "foo", null } );
     rowMeta.addValueMeta( new ValueMetaNumber( "number" ) );
     rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    rowMeta.addValueMeta( new ValueMetaNumber( "nullNumber" ) );
     getTestObject().next();
     assertThat( getTestObject().getDouble( "number" ), equalTo( 1.1 ) );
+    assertThat( getTestObject().wasNull(), equalTo( false ) );
     assertThat( getTestObject().getFloat( "number" ), equalTo( 1.1f ) );
+    assertThat( getTestObject().getDouble( "nullNumber" ), equalTo( 0.0 ) );
+    assertThat( getTestObject().wasNull(), equalTo( true ) );
   }
 
   @Test public void testGetBigDecimal() throws Exception {
-    setNextRow( new Object[] { 1.1, "foo" } );
+    setNextRow( new Object[] { 1.1, "foo", null } );
     rowMeta.addValueMeta( new ValueMetaNumber( "number" ) );
     rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    rowMeta.addValueMeta( new ValueMetaNumber( "nullBigDec" ) );
     getTestObject().next();
     assertThat( getTestObject().getBigDecimal( "number" ).doubleValue(), equalTo( 1.1 ) );
+    assertThat( getTestObject().getBigDecimal( "nullBigDec" ), nullValue() );
+    assertThat( getTestObject().wasNull(), equalTo( true ) );
   }
 
   @Test public void testGetByte() throws Exception {
     byte b = 'a';
-    setNextRow( new Object[] { new Byte( b ).longValue(), "foo" } );
+    setNextRow( new Object[] { new Byte( b ).longValue(), "foo", null } );
     rowMeta.addValueMeta( new ValueMetaInteger( "byte" ) );
     rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "nullByte" ) );
     getTestObject().next();
     assertThat( getTestObject().getByte( "byte" ), equalTo( b ) );
+    assertThat( getTestObject().wasNull(), equalTo( false ) );
+    assertThat( getTestObject().getByte( "nullByte" ), equalTo( (byte) 0 ) );
+    assertThat( getTestObject().wasNull(), equalTo( true ) );
   }
 
   @Test public void testGetBytes() throws Exception {
-    setNextRow( new Object[] { "b", "foo" } );
+    setNextRow( new Object[] { "b", "foo", null } );
     rowMeta.addValueMeta( new ValueMetaString( "bytes" ) );
     rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "nullBytes" ) );
     getTestObject().next();
     assertThat( getTestObject().getBytes( "bytes" ), equalTo( new byte[] { 'b' } ) );
-
+    assertThat( getTestObject().wasNull(), equalTo( false ) );
+    assertThat( getTestObject().getBytes( "nullBytes" ), nullValue() );
+    assertThat( getTestObject().wasNull(), equalTo( true ) );
   }
 
   @Test public void testGetFloat() throws Exception {
-    setNextRow( new Object[] { 1.1, "foo" } );
+    setNextRow( new Object[] { 1.1, "foo", null } );
     rowMeta.addValueMeta( new ValueMetaNumber( "col" ) );
     rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    rowMeta.addValueMeta( new ValueMetaNumber( "nullCol" ) );
     getTestObject().next();
     assertThat( getTestObject().getFloat( "col" ), equalTo( 1.1f ) );
+    assertThat( getTestObject().wasNull(), equalTo( false ) );
+    assertThat( getTestObject().getFloat( "nullCol" ), equalTo( 0f ) );
+    assertThat( getTestObject().wasNull(), equalTo( true ) );
   }
 
   @Test public void testGetInt() throws Exception {
-    setNextRow( new Object[] { 1l, "foo" } );
+    setNextRow( new Object[] { 1l, "foo", null } );
     rowMeta.addValueMeta( new ValueMetaInteger( "col" ) );
     rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "nullCol" ) );
     getTestObject().next();
     assertThat( getTestObject().getInt( "col" ), equalTo( 1 ) );
+    assertThat( getTestObject().wasNull(), equalTo( false ) );
+    assertThat( getTestObject().getInt( "nullCol" ), equalTo( 0 ) );
+    assertThat( getTestObject().wasNull(), equalTo( true ) );
 
   }
 
   @Test public void testGetLong() throws Exception {
-    setNextRow( new Object[] { 1l, "foo" } );
+    setNextRow( new Object[] { 1l, "foo", null } );
     rowMeta.addValueMeta( new ValueMetaInteger( "col" ) );
     rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "nullCol" ) );
     getTestObject().next();
     assertThat( getTestObject().getLong( "col" ), equalTo( 1l ) );
+    assertThat( getTestObject().wasNull(), equalTo( false ) );
     assertThat( getTestObject().getInt( "col" ), equalTo( 1 ) );
+    assertThat( getTestObject().getLong( "nullCol" ), equalTo( 0l ) );
+    assertThat( getTestObject().wasNull(), equalTo( true ) );
   }
 
   @Test public void testGetShort() throws Exception {
-    setNextRow( new Object[] { 1l, "foo" } );
+    setNextRow( new Object[] { 1l, "foo", null } );
     rowMeta.addValueMeta( new ValueMetaInteger( "col" ) );
     rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    rowMeta.addValueMeta( new ValueMetaInteger( "nullCol" ) );
     short s = 1;
     getTestObject().next();
     assertThat( getTestObject().getShort( "col" ), equalTo( s ) );
-
+    assertThat( getTestObject().wasNull(), equalTo( false ) );
+    assertThat( getTestObject().getShort( "nullCol" ), equalTo( (short) 0 ) );
+    assertThat( getTestObject().wasNull(), equalTo( true ) );
   }
 
   @Test public void testGetString() throws Exception {
-    setNextRow( new Object[] { "a string", "foo" } );
+    setNextRow( new Object[] { "a string", "foo", null } );
     rowMeta.addValueMeta( new ValueMetaString( "col" ) );
     rowMeta.addValueMeta( new ValueMetaString( "string" ) );
+    rowMeta.addValueMeta( new ValueMetaString( "nullString" ) );
     getTestObject().next();
     assertThat( getTestObject().getString( "col" ), equalTo( "a string" ) );
+    assertThat( getTestObject().wasNull(), equalTo( false ) );
     assertThat( getTestObject().getObject( "col", String.class ), equalTo( "a string" ) );
+    assertThat( getTestObject().getString( "nullString" ), nullValue() );
+    assertThat( getTestObject().wasNull(), equalTo( true ) );
   }
 
   @Test


### PR DESCRIPTION
BaseResultSet methods which return primitives cannot return null.
For example, .getLong cannot return null if the SQL field value is
SQL NULL.  The spec gives a default value of 0l in such a case,
and the client can determine null by using the .wasNull() method.
(cherry picked from commit d9271a5)

wingman run on master:  http://10.100.11.222:8080/job/wingman-mvn/140/console

@kcruzada 
