### PR TITLE
[BACKLOG-5353] Remove deprecated ThinDriver and related classes from kettle core

### DIFF
--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/core/jdbc/FoundClause.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/core/jdbc/FoundClause.java
@@ -1,0 +1,48 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.jdbc;
+
+/**
+ * This class is no longer used
+ *
+ * Data Service client code is now available in the pdi-dataservice-plugin project
+ *
+ */
+@Deprecated
+public class FoundClause {
+  private final String clause;
+  private final String rest;
+
+  public FoundClause( String clause, String rest ) {
+    this.clause = clause;
+    this.rest = rest;
+  }
+
+  public String getClause() {
+    return clause;
+  }
+
+  public String getRest() {
+    return rest;
+  }
+}

--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/core/jdbc/ThinUtil.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/core/jdbc/ThinUtil.java
@@ -1,0 +1,659 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.jdbc;
+
+import java.math.BigDecimal;
+import java.sql.SQLException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleSQLException;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.ValueMetaAndData;
+import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.core.row.value.ValueMetaBigNumber;
+import org.pentaho.di.core.row.value.ValueMetaBinary;
+import org.pentaho.di.core.row.value.ValueMetaBoolean;
+import org.pentaho.di.core.row.value.ValueMetaDate;
+import org.pentaho.di.core.row.value.ValueMetaInteger;
+import org.pentaho.di.core.row.value.ValueMetaNone;
+import org.pentaho.di.core.row.value.ValueMetaNumber;
+import org.pentaho.di.core.row.value.ValueMetaString;
+import org.pentaho.di.core.xml.XMLHandler;
+
+/**
+ * Static methods provided by this class should be copied to their respective projects
+ *
+ * Data Service client code is now available in the pdi-dataservice-plugin project
+ *
+ */
+@Deprecated
+public class ThinUtil {
+
+  public static String stripNewlines( String sql ) {
+    if ( sql == null ) {
+      return null;
+    }
+
+    StringBuilder sbsql = new StringBuilder( sql );
+
+    for ( int i = sbsql.length() - 1; i >= 0; i-- ) {
+      if ( sbsql.charAt( i ) == '\n' || sbsql.charAt( i ) == '\r' ) {
+        sbsql.setCharAt( i, ' ' );
+      }
+    }
+    return sbsql.toString();
+  }
+
+  public static int getSqlType( ValueMetaInterface valueMeta ) {
+    switch ( valueMeta.getType() ) {
+      case ValueMetaInterface.TYPE_STRING:
+        return java.sql.Types.VARCHAR;
+      case ValueMetaInterface.TYPE_DATE:
+        return java.sql.Types.TIMESTAMP;
+      case ValueMetaInterface.TYPE_INTEGER:
+        return java.sql.Types.BIGINT; // TODO: for metadata we don't want a long?
+      case ValueMetaInterface.TYPE_BIGNUMBER:
+        return java.sql.Types.DECIMAL;
+      case ValueMetaInterface.TYPE_NUMBER:
+        return java.sql.Types.DOUBLE;
+      case ValueMetaInterface.TYPE_BOOLEAN:
+        return java.sql.Types.BOOLEAN;
+      case ValueMetaInterface.TYPE_BINARY:
+        return java.sql.Types.BLOB;
+      case ValueMetaInterface.TYPE_NONE:
+        return java.sql.Types.OTHER;
+      default:
+        break;
+    }
+    return java.sql.Types.VARCHAR;
+  }
+
+  public static String getSqlTypeDesc( ValueMetaInterface valueMeta ) {
+    switch ( valueMeta.getType() ) {
+      case ValueMetaInterface.TYPE_STRING:
+        return "VARCHAR";
+      case ValueMetaInterface.TYPE_DATE:
+        return "TIMESTAMP";
+      case ValueMetaInterface.TYPE_INTEGER:
+        return "BIGINT"; // TODO: for metadata we don't want a long?
+      case ValueMetaInterface.TYPE_NUMBER:
+        return "DOUBLE";
+      case ValueMetaInterface.TYPE_BIGNUMBER:
+        return "DECIMAL";
+      case ValueMetaInterface.TYPE_BOOLEAN:
+        return "BOOLEAN";
+      case ValueMetaInterface.TYPE_BINARY:
+        return "BLOB";
+      case ValueMetaInterface.TYPE_NONE:
+        return "OTHER";
+      default:
+        break;
+    }
+    return null;
+  }
+
+  public static ValueMetaInterface getValueMeta( String valueName, int sqlType ) throws SQLException {
+    switch ( sqlType ) {
+      case java.sql.Types.OTHER:
+      case java.sql.Types.NULL:
+        return new ValueMetaNone( valueName );
+
+      case java.sql.Types.BIGINT:
+      case java.sql.Types.INTEGER:
+      case java.sql.Types.SMALLINT:
+        return new ValueMetaInteger( valueName );
+
+      case java.sql.Types.CHAR:
+      case java.sql.Types.VARCHAR:
+      case java.sql.Types.CLOB:
+        return new ValueMetaString( valueName );
+
+      case java.sql.Types.DATE:
+      case java.sql.Types.TIMESTAMP:
+      case java.sql.Types.TIME:
+        return new ValueMetaDate( valueName );
+
+      case java.sql.Types.DECIMAL:
+        return new ValueMetaBigNumber( valueName );
+
+      case java.sql.Types.DOUBLE:
+      case java.sql.Types.FLOAT:
+        return new ValueMetaNumber( valueName );
+
+      case java.sql.Types.BOOLEAN:
+      case java.sql.Types.BIT:
+        return new ValueMetaBoolean( valueName );
+
+      case java.sql.Types.BINARY:
+      case java.sql.Types.BLOB:
+        return new ValueMetaBinary( valueName );
+
+      default:
+        throw new SQLException( "Don't know how to handle SQL Type: " + sqlType + ", with name: " + valueName );
+    }
+  }
+
+  public static ValueMetaAndData attemptDateValueExtraction( String string ) {
+    if ( string.length() > 2 && string.startsWith( "[" ) && string.endsWith( "]" ) ) {
+      String unquoted = string.substring( 1, string.length() - 1 );
+      if ( unquoted.length() >= 9 && unquoted.charAt( 4 ) == '/' && unquoted.charAt( 7 ) == '/' ) {
+        Date date = XMLHandler.stringToDate( unquoted );
+        String format = "yyyy/MM/dd HH:mm:ss.SSS";
+        if ( date == null ) {
+          try {
+            date = new SimpleDateFormat( "yyyy/MM/dd HH:mm:ss" ).parse( unquoted );
+            format = "yyyy/MM/dd HH:mm:ss";
+          } catch ( ParseException e1 ) {
+            try {
+              date = new SimpleDateFormat( "yyyy/MM/dd" ).parse( unquoted );
+              format = "yyyy/MM/dd";
+            } catch ( ParseException e2 ) {
+              date = null;
+            }
+          }
+        }
+        if ( date != null ) {
+          ValueMetaInterface valueMeta = new ValueMeta( "iif-date", ValueMetaInterface.TYPE_DATE );
+          valueMeta.setConversionMask( format );
+          return new ValueMetaAndData( valueMeta, date );
+        }
+      }
+    }
+
+    Matcher matcher = Pattern.compile( "^([A-Za-z]+) ?'([0-9\\-:\\. ]+)'$" ).matcher( string );
+    if ( matcher.find() ) {
+      if ( matcher.groupCount() == 2 ) {
+        String keyword = matcher.group( 1 );
+        String dateString = matcher.group( 2 );
+        String format = null;
+        if ( keyword.equalsIgnoreCase( "TIMESTAMP" ) ) {
+          format = "yyyy-MM-dd HH:mm:ss";
+        } else if ( keyword.equalsIgnoreCase( "DATE" ) ) {
+          format = "yyyy-MM-dd";
+        }
+        if ( format != null ) {
+          Date date = null;
+          try {
+            date = new SimpleDateFormat( format ).parse( dateString );
+          } catch ( ParseException e ) {
+            // Format does not match
+          }
+          if ( date != null ) {
+            ValueMetaInterface valueMeta = new ValueMeta( "iff-date", ValueMetaInterface.TYPE_DATE );
+            valueMeta.setConversionMask( format );
+            return new ValueMetaAndData( valueMeta, date );
+          }
+        }
+      }
+    }
+
+    return null;
+  }
+
+
+  public static ValueMetaAndData attemptIntegerValueExtraction( String string ) {
+    // Try an Integer
+    if ( !string.contains( "." ) ) {
+      try {
+        long l = Long.parseLong( string );
+        if ( Long.toString( l ).equals( string ) ) {
+          ValueMetaAndData value = new ValueMetaAndData();
+          ValueMetaInterface valueMeta = new ValueMeta( "Constant", ValueMetaInterface.TYPE_INTEGER );
+          valueMeta.setConversionMask( "0" );
+          valueMeta.setGroupingSymbol( null );
+          value.setValueMeta( valueMeta );
+          value.setValueData( Long.valueOf( l ) );
+          return value;
+        }
+      } catch ( NumberFormatException e ) {
+        // ignore - will return null below
+      }
+    }
+    return null;
+  }
+
+  public static ValueMetaAndData attemptNumberValueExtraction( String string ) {
+    // Try a Number
+    try {
+      double d = Double.parseDouble( string );
+      if ( Double.toString( d ).equals( string ) ) {
+        ValueMetaAndData value = new ValueMetaAndData();
+        ValueMetaInterface valueMeta = new ValueMeta( "Constant", ValueMetaInterface.TYPE_NUMBER );
+        valueMeta.setConversionMask( "0.#" );
+        valueMeta.setGroupingSymbol( null );
+        valueMeta.setDecimalSymbol( "." );
+        value.setValueMeta( valueMeta );
+        value.setValueData( Double.valueOf( d ) );
+        return value;
+      }
+    } catch ( NumberFormatException e ) {
+      // ignore - will return null below
+    }
+    return null;
+  }
+
+  public static ValueMetaAndData attemptBigNumberValueExtraction( String string ) {
+    // Try a BigNumber
+    try {
+      BigDecimal d = new BigDecimal( string );
+      if ( d.toString().equals( string ) ) {
+        ValueMetaAndData value = new ValueMetaAndData();
+        value.setValueMeta( new ValueMeta( "Constant", ValueMetaInterface.TYPE_BIGNUMBER ) );
+        value.setValueData( d );
+        return value;
+      }
+    } catch ( NumberFormatException e ) {
+      // ignore - will return null below
+    }
+    return null;
+  }
+
+  public static ValueMetaAndData attemptStringValueExtraction( String string ) {
+    if ( string.startsWith( "'" ) && string.endsWith( "'" ) ) {
+      String s = string.substring( 1, string.length() - 1 );
+
+      // Make sure to replace quoted '' occurrences.
+      //
+      s = s.replace( "''", "'" );
+
+      ValueMetaAndData value = new ValueMetaAndData();
+      value.setValueMeta( new ValueMeta( "Constant", ValueMetaInterface.TYPE_STRING ) );
+      value.setValueData( s );
+      return value;
+    }
+    return null;
+  }
+
+  public static ValueMetaAndData attemptBooleanValueExtraction( String string ) {
+    // Try an Integer
+    if ( "TRUE".equalsIgnoreCase( string ) || "FALSE".equalsIgnoreCase( string ) ) {
+      ValueMetaAndData value = new ValueMetaAndData();
+      value.setValueMeta( new ValueMeta( "Constant", ValueMetaInterface.TYPE_BOOLEAN ) );
+      value.setValueData( Boolean.valueOf( "TRUE".equalsIgnoreCase( string ) ) );
+      return value;
+    }
+    return null;
+  }
+
+  public static ValueMetaAndData extractConstant( String string ) {
+    // Try a date
+    //
+    ValueMetaAndData value = attemptDateValueExtraction( string );
+    if ( value != null ) {
+      return value;
+    }
+
+    // String
+    value = attemptStringValueExtraction( string );
+    if ( value != null ) {
+      return value;
+    }
+
+    // Boolean
+    value = attemptBooleanValueExtraction( string );
+    if ( value != null ) {
+      return value;
+    }
+
+    // Integer
+    value = attemptIntegerValueExtraction( string );
+    if ( value != null ) {
+      return value;
+    }
+
+    // Number
+    value = attemptNumberValueExtraction( string );
+    if ( value != null ) {
+      return value;
+    }
+
+    // Number
+    value = attemptBigNumberValueExtraction( string );
+    if ( value != null ) {
+      return value;
+    }
+
+    return null;
+  }
+
+  public static String stripQuoteTableAlias( String field, String tableAliasPrefix ) {
+    String result = stripTableAlias( field, tableAliasPrefix );
+    if ( result.equals( field ) ) {
+      result = ThinUtil.stripQuotes( Const.trim( field ), '"' );
+    }
+    return result;
+  }
+
+  public static String stripTableAlias( String field, String tableAliasPrefix ) {
+    if ( field.toUpperCase().startsWith( ( tableAliasPrefix + "." ).toUpperCase() ) ) {
+      return ThinUtil.stripQuotesIfNoWhitespace(
+        field.substring( tableAliasPrefix.length() + 1 ), '"' );
+    } else if ( field.toUpperCase().startsWith( ( "\"" + tableAliasPrefix + "\"." ).toUpperCase() ) ) {
+      return ThinUtil.stripQuotesIfNoWhitespace(
+        field.substring( tableAliasPrefix.length() + 3 ), '"' );
+    } else {
+      return field;
+    }
+  }
+
+  public static int skipChars( String sql, int index, char... skipChars ) throws KettleSQLException {
+    if ( index >= sql.length() ) {
+      return index;
+    }
+
+    // Skip over double quotes and quotes
+    char c = sql.charAt( index );
+    boolean count = false;
+    for ( char skipChar : skipChars ) {
+      if ( c == skipChar ) {
+        char nextChar = skipChar;
+        if ( skipChar == '(' ) {
+          nextChar = ')';
+          count = true;
+        }
+        if ( skipChar == '{' ) {
+          nextChar = '}';
+          count = true;
+        }
+        if ( skipChar == '[' ) {
+          nextChar = ']';
+          count = true;
+        }
+
+        if ( count ) {
+          index = findNextBracket( sql, skipChar, nextChar, index );
+        } else {
+          // Make sure to take escaping into account for single quotes
+          //
+          index = findNext( sql, nextChar, index, skipChar == '\'' );
+        }
+        if ( index >= sql.length() ) {
+          break;
+        }
+        c = sql.charAt( index );
+      }
+    }
+
+    return index;
+  }
+
+  public static int findNext( String sql, char nextChar, int index ) throws KettleSQLException {
+    return findNext( sql, nextChar, index, false );
+  }
+
+  public static int findNext( String sql, char nextChar, int index, boolean escape ) throws KettleSQLException {
+    int quoteIndex = index;
+
+    while ( true ) {
+
+      index++;
+
+      if ( index >= sql.length() ) {
+        break;
+      }
+      boolean quoteMatch = sql.charAt( index ) == nextChar;
+      if ( quoteMatch ) {
+        boolean escaped = escape && index + 1 < sql.length() && sql.charAt( index + 1 ) == nextChar;
+
+        if ( quoteMatch && !escaped ) {
+          break;
+        }
+        if ( escaped ) {
+          index++; // skip one more
+        }
+      }
+    }
+
+    if ( index + 1 > sql.length() ) {
+      throw new KettleSQLException( "No closing " + nextChar + " found, starting at location " + quoteIndex + " in : ["
+          + sql + "]" );
+    }
+    index++;
+    return index;
+  }
+
+  public static int findNextBracket( String sql, char skipChar, char nextChar, int index ) throws KettleSQLException {
+    return findNextBracket( sql, skipChar, nextChar, index, false );
+  }
+
+  public static int findNextBracket( String sql, char skipChar, char nextChar, int index, boolean escape )
+    throws KettleSQLException {
+
+    int counter = 0;
+    for ( int i = index; i < sql.length(); i++ ) {
+      i = skipChars( sql, i, '\'' ); // skip quotes
+      if ( i >= sql.length() ) {
+        break;
+      }
+      char c = sql.charAt( i );
+      if ( c == skipChar ) {
+        counter++;
+      }
+      if ( c == nextChar ) {
+        counter--;
+      }
+      if ( counter == 0 ) {
+        return i;
+      }
+    }
+
+    throw new KettleSQLException( "No closing " + nextChar + " bracket found for " + skipChar + " at location " + index
+        + " in : [" + sql + "]" );
+  }
+
+  public static String stripQuotes( String string, char... quoteChars ) {
+    StringBuilder builder = new StringBuilder( string );
+    for ( char quoteChar : quoteChars ) {
+      if ( countQuotes( builder.toString(), quoteChar ) == 2 ) {
+        if ( builder.length() > 0 && builder.charAt( 0 ) == quoteChar
+            && builder.charAt( builder.length() - 1 ) == quoteChar ) {
+          // If there are quotes in between, don't do it...
+          //
+          builder.deleteCharAt( builder.length() - 1 );
+          builder.deleteCharAt( 0 );
+        }
+      }
+    }
+    return builder.toString();
+  }
+
+  /**
+   * Strips leading and trailing quotes if no whitespace present, and no
+   * additional quotes in the string.
+   */
+  public static String stripQuotesIfNoWhitespace(
+    String string, char... quoteChars ) {
+    if ( string.matches( ".*\\s.*" ) ) {
+      // whitespace present
+      return string;
+    }
+    return stripQuotes( string, quoteChars );
+  }
+
+  private static int countQuotes( String string, char quoteChar ) {
+    int count = 0;
+    for ( int i = 0; i < string.length(); i++ ) {
+      if ( string.charAt( i ) == quoteChar ) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  public static List<String> splitClause( String fieldClause, char splitChar, char... skipChars )
+    throws KettleSQLException {
+    List<String> strings = new ArrayList<String>();
+    int startIndex = 0;
+    for ( int index = 0; index < fieldClause.length(); index++ ) {
+      index = ThinUtil.skipChars( fieldClause, index, skipChars );
+      if ( index >= fieldClause.length() ) {
+        strings.add( fieldClause.substring( startIndex ) );
+        startIndex = -1;
+        break;
+      }
+      // The CASE-WHEN-THEN-ELSE-END Hack // TODO: factor out
+      //
+      if ( fieldClause.substring( index ).toUpperCase().startsWith( "CASE WHEN " ) ) {
+        // If we see CASE-WHEN then we skip to END
+        //
+        index = skipOverClause( fieldClause, index, " END" );
+      }
+
+      if ( index < fieldClause.length() && fieldClause.charAt( index ) == splitChar ) {
+        strings.add( fieldClause.substring( startIndex, index ) );
+        while ( index < fieldClause.length() && fieldClause.charAt( index ) == splitChar ) {
+          index++;
+        }
+        startIndex = index;
+        index--;
+      }
+    }
+    if ( startIndex >= 0 ) {
+      strings.add( fieldClause.substring( startIndex ) );
+    }
+
+    return strings;
+  }
+
+  private static int skipOverClause( String fieldClause, int index, String clause ) throws KettleSQLException {
+    while ( index < fieldClause.length() ) {
+      index = skipChars( fieldClause, index, '\'', '"' );
+      if ( fieldClause.substring( index ).toUpperCase().startsWith( clause.toUpperCase() ) ) {
+        return index + clause.length();
+      }
+      index++;
+    }
+    return fieldClause.length();
+  }
+
+  public static String findClause( String sqlString, String startClause, String... endClauses )
+    throws KettleSQLException {
+    return findClauseWithRest( sqlString, startClause, endClauses ).getClause();
+  }
+
+  public static FoundClause findClauseWithRest( String sqlString, String startClause, String... endClauses )
+    throws KettleSQLException {
+    if ( Const.isEmpty( sqlString ) ) {
+      return new FoundClause( null, null );
+    }
+
+    String sql = sqlString.toUpperCase();
+
+    int startIndex = 0;
+    while ( startIndex < sql.length() ) {
+      startIndex = ThinUtil.skipChars( sql, startIndex, '"', '\'' );
+      if ( sql.substring( startIndex ).startsWith( startClause.toUpperCase() ) ) {
+        break;
+      }
+      startIndex++;
+    }
+
+    if ( startIndex < 0 || startIndex >= sql.length() ) {
+      return new FoundClause( null, sqlString );
+    }
+
+    startIndex += startClause.length() + 1;
+    if ( endClauses.length == 0 ) {
+      return new FoundClause( sqlString.substring( startIndex ), null );
+    }
+
+    // Index of first character of end clause
+    int endIndex = sql.length();
+
+    for ( String endClause : endClauses ) {
+
+      int index = startIndex;
+      while ( index < endIndex ) {
+        index = ThinUtil.skipChars( sql, index, '"', '\'' );
+
+        // See if the end-clause is present at this location.
+        //
+        if ( sql.substring( index ).startsWith( endClause.toUpperCase() ) ) {
+          if ( index < endIndex ) {
+            endIndex = index;
+          }
+        }
+        index++;
+      }
+    }
+    String foundClause = Const.trim( sqlString.substring( startIndex, endIndex ) );
+    String rest = null;
+    if ( endIndex < sql.length() ) {
+      rest = Const.trim( sqlString.substring( endIndex ) );
+      if ( rest.length() == 0 ) {
+        rest = null;
+      }
+    }
+    return new FoundClause( foundClause, rest );
+  }
+
+  public static boolean like( String subject, String pattern ) {
+    return like( pattern ).matcher( subject ).matches();
+  }
+
+  public static Pattern like( String pattern ) {
+    if ( pattern == null ) {
+      throw new IllegalArgumentException( "Pattern cannot be null" );
+    }
+
+    // Escape regex meta characters
+    int len = pattern.length();
+    if ( len > 0 ) {
+      StringBuilder sb = new StringBuilder( len * 2 );
+      for ( int i = 0; i < len; i++ ) {
+        char c = pattern.charAt( i );
+        if ( "[](){}.*+?$^|#\\".indexOf( c ) != -1 ) {
+          sb.append( '\\' );
+        }
+        sb.append( c );
+      }
+      pattern = sb.toString();
+    }
+
+    // Translate LIKE operators to REGEX
+    pattern = pattern.replace( "_", "." ).replace( "%", ".*?" );
+
+    return Pattern.compile( pattern, Pattern.CASE_INSENSITIVE | Pattern.DOTALL );
+  }
+
+  /**
+   * Attempts to resolve the reference to field from the serviceFields value meta list.
+   * Will search with both the quoted and unquoted field.
+   */
+  public static String resolveFieldName( String field, RowMetaInterface serviceFields ) {
+    ValueMetaInterface valueMeta = serviceFields.searchValueMeta( field );
+    if ( valueMeta == null ) {
+      valueMeta = serviceFields.searchValueMeta(
+        ThinUtil.stripQuotes( field, '"' ) );
+    }
+    return valueMeta == null ? field : valueMeta.getName();
+  }
+}

--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/IifFunction.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/IifFunction.java
@@ -1,0 +1,181 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.sql;
+
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleSQLException;
+import org.pentaho.di.core.jdbc.ThinUtil;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaAndData;
+
+public class IifFunction {
+  private String tableAlias;
+  private String conditionClause;
+  private SQLCondition sqlCondition;
+  private RowMetaInterface serviceFields;
+
+  private String trueValueString;
+  private ValueMetaAndData trueValue;
+  private boolean trueField;
+  private String falseValueString;
+  private ValueMetaAndData falseValue;
+  private boolean falseField;
+
+  public IifFunction( String tableAlias, String conditionClause, String trueValueString, String falseValueString,
+    RowMetaInterface serviceFields ) throws KettleSQLException {
+    this.tableAlias = tableAlias;
+    this.conditionClause = conditionClause;
+    this.trueValueString = trueValueString;
+    this.falseValueString = falseValueString;
+    this.serviceFields = serviceFields;
+
+    // Parse the SQL
+    this.sqlCondition = new SQLCondition( tableAlias, conditionClause, serviceFields );
+
+    // rudimentary string, date, number, integer determination
+    //
+    trueValue = extractValue( trueValueString, true );
+    falseValue = extractValue( falseValueString, false );
+  }
+
+  private ValueMetaAndData extractValue( String string, boolean trueIndicator ) throws KettleSQLException {
+    if ( Const.isEmpty( string ) ) {
+      return null;
+    }
+
+    ValueMetaAndData value = ThinUtil.attemptDateValueExtraction( string );
+    if ( value != null ) {
+      return value;
+    }
+
+    value = ThinUtil.attemptStringValueExtraction( string );
+    if ( value != null ) {
+      return value;
+    }
+
+    // See if it's a field...
+    //
+    int index = serviceFields.indexOfValue( string );
+    if ( index >= 0 ) {
+      if ( trueIndicator ) {
+        trueField = true;
+      } else {
+        falseField = true;
+      }
+      return new ValueMetaAndData( serviceFields.getValueMeta( index ), null );
+    }
+
+    value = ThinUtil.attemptBooleanValueExtraction( string );
+    if ( value != null ) {
+      return value;
+    }
+
+    value = ThinUtil.attemptIntegerValueExtraction( string );
+    if ( value != null ) {
+      return value;
+    }
+
+    value = ThinUtil.attemptNumberValueExtraction( string );
+    if ( value != null ) {
+      return value;
+    }
+
+    value = ThinUtil.attemptBigNumberValueExtraction( string );
+    if ( value != null ) {
+      return value;
+    }
+
+    throw new KettleSQLException( "Unable to determine value data type for string: [" + string + "]" );
+  }
+
+  /**
+   * @return the conditionClause
+   */
+  public String getConditionClause() {
+    return conditionClause;
+  }
+
+  /**
+   * @return the sqlCondition
+   */
+  public SQLCondition getSqlCondition() {
+    return sqlCondition;
+  }
+
+  /**
+   * @return the serviceFields
+   */
+  public RowMetaInterface getServiceFields() {
+    return serviceFields;
+  }
+
+  /**
+   * @return the trueValueString
+   */
+  public String getTrueValueString() {
+    return trueValueString;
+  }
+
+  /**
+   * @return the trueValue
+   */
+  public ValueMetaAndData getTrueValue() {
+    return trueValue;
+  }
+
+  /**
+   * @return the falseValueString
+   */
+  public String getFalseValueString() {
+    return falseValueString;
+  }
+
+  /**
+   * @return the falseValue
+   */
+  public ValueMetaAndData getFalseValue() {
+    return falseValue;
+  }
+
+  /**
+   * @return the falseField
+   */
+  public boolean isFalseField() {
+    return falseField;
+  }
+
+  /**
+   * @return the trueField
+   */
+  public boolean isTrueField() {
+    return trueField;
+  }
+
+  /**
+   * @return the tableAlias
+   */
+  public String getTableAlias() {
+    return tableAlias;
+  }
+
+}

--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQL.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQL.java
@@ -1,0 +1,426 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.sql;
+
+import java.util.List;
+
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleSQLException;
+import org.pentaho.di.core.jdbc.FoundClause;
+import org.pentaho.di.core.jdbc.ThinUtil;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+
+public class SQL {
+  private String sqlString;
+
+  private RowMetaInterface rowMeta;
+
+  private String serviceClause;
+  private String namespace;
+  private String serviceName;
+  private String serviceAlias;
+
+  private String selectClause;
+  private SQLFields selectFields;
+
+  private String whereClause;
+  private SQLCondition whereCondition;
+
+  private String groupClause;
+  private SQLFields groupFields;
+
+  private String havingClause;
+  private SQLCondition havingCondition;
+
+  private String orderClause;
+  private SQLFields orderFields;
+
+  private String limitClause;
+  private SQLLimit limitValues;
+
+  /**
+   * Create a new SQL object by parsing the supplied SQL string. This is a simple implementation with only one table
+   * allows
+   * 
+   * @param sqlString
+   *          the SQL string to parse
+   * @param serviceName
+   *          the name of the service this SQL references
+   * @param rowMeta
+   *          the row layout of the service
+   * @throws KettleSQLException
+   *           in case there is a SQL parsing error
+   */
+  public SQL( String sqlString ) throws KettleSQLException {
+    this.sqlString = sqlString;
+
+    splitSql( sqlString );
+  }
+
+  private void splitSql( String sql ) throws KettleSQLException {
+    // First get the major blocks...
+    /*
+     * SELECT A, B, C FROM Step
+     * 
+     * SELECT A, B, C FROM Step WHERE D > 6 AND E = 'abcd'
+     * 
+     * SELECT A, B, C FROM Step ORDER BY B, A, C
+     * 
+     * SELECT A, B, sum(C) FROM Step WHERE D > 6 AND E = 'abcd' GROUP BY A, B HAVING sum(C) > 100 ORDER BY sum(C) DESC
+     */
+    //
+    FoundClause foundClause = ThinUtil.findClauseWithRest( sql, "SELECT", "FROM" );
+    selectClause = foundClause.getClause();
+    if ( foundClause.getRest() == null ) {
+      return;
+    }
+    foundClause = ThinUtil.findClauseWithRest( foundClause.getRest(), "FROM", "WHERE", "GROUP BY", "ORDER BY", "LIMIT" );
+    serviceClause = foundClause.getClause();
+    parseServiceClause();
+    if ( foundClause.getRest() == null ) {
+      return;
+    }
+    foundClause = ThinUtil.findClauseWithRest( foundClause.getRest(), "WHERE", "GROUP BY", "ORDER BY", "LIMIT" );
+    whereClause = foundClause.getClause();
+    if ( foundClause.getRest() == null ) {
+      return;
+    }
+    foundClause = ThinUtil.findClauseWithRest( foundClause.getRest(), "GROUP BY", "HAVING", "ORDER BY", "LIMIT" );
+    groupClause = foundClause.getClause();
+    if ( foundClause.getRest() == null ) {
+      return;
+    }
+    foundClause = ThinUtil.findClauseWithRest( foundClause.getRest(), "HAVING", "ORDER BY", "LIMIT" );
+    havingClause = foundClause.getClause();
+    if ( foundClause.getRest() == null ) {
+      return;
+    }
+    foundClause = ThinUtil.findClauseWithRest( foundClause.getRest(), "ORDER BY", "LIMIT" );
+    orderClause = foundClause.getClause();
+    if ( foundClause.getRest() == null ) {
+      return;
+    }
+    foundClause = ThinUtil.findClauseWithRest( foundClause.getRest(), "LIMIT" );
+    limitClause = foundClause.getClause();
+  }
+
+  private void parseServiceClause() throws KettleSQLException {
+    if ( Const.isEmpty( serviceClause ) ) {
+      serviceName = "dual";
+      return;
+    }
+
+    List<String> parts = ThinUtil.splitClause( serviceClause, ' ', '"' );
+    if ( parts.size() >= 1 ) {
+      // The service name is in the first part/
+      // However, it can be in format Namespace.Service (Schema.Table)
+      //
+      List<String> list = ThinUtil.splitClause( parts.get( 0 ), '.', '"' );
+      if ( list.size() == 1 ) {
+        namespace = null;
+        serviceName = ThinUtil.stripQuotes( list.get( 0 ), '"' );
+      }
+      if ( list.size() == 2 ) {
+        namespace = ThinUtil.stripQuotes( list.get( 0 ), '"' );
+        serviceName = ThinUtil.stripQuotes( list.get( 1 ), '"' );
+      }
+      if ( list.size() > 2 ) {
+        throw new KettleSQLException( "Too many parts detected in table name specification [" + serviceClause + "]" );
+      }
+    }
+
+    if ( parts.size() == 2 ) {
+      serviceAlias = ThinUtil.stripQuotes( parts.get( 1 ), '"' );
+    }
+    if ( parts.size() == 3 ) {
+
+      if ( parts.get( 1 ).equalsIgnoreCase( "AS" ) ) {
+        serviceAlias = ThinUtil.stripQuotes( parts.get( 2 ), '"' );
+      } else {
+        throw new KettleSQLException( "AS expected in from clause: " + serviceClause );
+      }
+    }
+    if ( parts.size() > 3 ) {
+      StringBuilder builder = new StringBuilder();
+      builder.append( "Found " );
+      builder.append( parts.size() );
+      builder.append( " parts for the FROM clause when only a table name and optionally an alias is supported: " );
+      builder.append( serviceClause );
+      throw new KettleSQLException( builder.toString() );
+    }
+
+    serviceAlias = Const.NVL( serviceAlias, serviceName );
+  }
+
+  public void parse( RowMetaInterface rowMeta ) throws KettleSQLException {
+
+    // Now do the actual parsing and interpreting of the SQL, map it to the service row metadata
+
+    this.rowMeta = rowMeta;
+
+    selectFields = new SQLFields( serviceAlias, rowMeta, selectClause );
+    if ( !Const.isEmpty( whereClause ) ) {
+      whereCondition = new SQLCondition( serviceAlias, whereClause, rowMeta );
+    }
+    if ( !Const.isEmpty( groupClause ) ) {
+      groupFields = new SQLFields( serviceAlias, rowMeta, groupClause );
+    } else {
+      groupFields = new SQLFields( serviceAlias, new RowMeta(), null );
+    }
+    if ( !Const.isEmpty( havingClause ) ) {
+      havingCondition = new SQLCondition( serviceAlias, havingClause, rowMeta, selectFields );
+    }
+    if ( !Const.isEmpty( orderClause ) ) {
+      orderFields = new SQLFields( serviceAlias, rowMeta, orderClause, true, selectFields );
+    }
+    if ( !Const.isEmpty( limitClause ) ) {
+      limitValues = new SQLLimit( limitClause );
+    }
+  }
+
+  public String getSqlString() {
+    return sqlString;
+  }
+
+  public RowMetaInterface getRowMeta() {
+    return rowMeta;
+  }
+
+  public String getServiceName() {
+    return serviceName;
+  }
+
+  /**
+   * @return the selectClause
+   */
+  public String getSelectClause() {
+    return selectClause;
+  }
+
+  /**
+   * @param selectClause
+   *          the selectClause to set
+   */
+  public void setSelectClause( String selectClause ) {
+    this.selectClause = selectClause;
+  }
+
+  /**
+   * @return the whereClause
+   */
+  public String getWhereClause() {
+    return whereClause;
+  }
+
+  /**
+   * @param whereClause
+   *          the whereClause to set
+   */
+  public void setWhereClause( String whereClause ) {
+    this.whereClause = whereClause;
+  }
+
+  /**
+   * @return the groupClause
+   */
+  public String getGroupClause() {
+    return groupClause;
+  }
+
+  /**
+   * @param groupClause
+   *          the groupClause to set
+   */
+  public void setGroupClause( String groupClause ) {
+    this.groupClause = groupClause;
+  }
+
+  /**
+   * @return the havingClause
+   */
+  public String getHavingClause() {
+    return havingClause;
+  }
+
+  /**
+   * @param havingClause
+   *          the havingClause to set
+   */
+  public void setHavingClause( String havingClause ) {
+    this.havingClause = havingClause;
+  }
+
+  /**
+   * @return the orderClause
+   */
+  public String getOrderClause() {
+    return orderClause;
+  }
+
+  /**
+   * @param orderClause
+   *          the orderClause to set
+   */
+  public void setOrderClause( String orderClause ) {
+    this.orderClause = orderClause;
+  }
+
+  /**
+   * @return the limitClause
+   */
+  public String getLimitClause() {
+    return limitClause;
+  }
+
+  /**
+   * @param limitClause the orderClause to set
+   */
+  public void setLimitClause( String limitClause ) {
+    this.limitClause = limitClause;
+  }
+
+  /**
+   *
+   * @return the limitValues
+   */
+  public SQLLimit getLimitValues() {
+    return limitValues;
+  }
+
+  /**
+   *
+   * @param limitValues the limitValues to set
+   *
+   */
+  public void setLimitValues( SQLLimit limitValues ) {
+    this.limitValues = limitValues;
+  }
+
+  /**
+   * @param sqlString
+   *          the sql string to set
+   */
+  public void setSqlString( String sqlString ) {
+    this.sqlString = sqlString;
+  }
+
+  /**
+   * @return the selectFields
+   */
+  public SQLFields getSelectFields() {
+    return selectFields;
+  }
+
+  /**
+   * @param selectFields
+   *          the selectFields to set
+   */
+  public void setSelectFields( SQLFields selectFields ) {
+    this.selectFields = selectFields;
+  }
+
+  /**
+   * @return the groupFields
+   */
+  public SQLFields getGroupFields() {
+    return groupFields;
+  }
+
+  /**
+   * @param groupFields
+   *          the groupFields to set
+   */
+  public void setGroupFields( SQLFields groupFields ) {
+    this.groupFields = groupFields;
+  }
+
+  /**
+   * @return the orderFields
+   */
+  public SQLFields getOrderFields() {
+    return orderFields;
+  }
+
+  /**
+   * @param orderFields
+   *          the orderFields to set
+   */
+  public void setOrderFields( SQLFields orderFields ) {
+    this.orderFields = orderFields;
+  }
+
+  /**
+   * @return the whereCondition
+   */
+  public SQLCondition getWhereCondition() {
+    return whereCondition;
+  }
+
+  /**
+   * @param whereCondition
+   *          the whereCondition to set
+   */
+  public void setWhereCondition( SQLCondition whereCondition ) {
+    this.whereCondition = whereCondition;
+  }
+
+  /**
+   * @param rowMeta
+   *          the rowMeta to set
+   */
+  public void setRowMeta( RowMetaInterface rowMeta ) {
+    this.rowMeta = rowMeta;
+  }
+
+  /**
+   * @param serviceName
+   *          the serviceName to set
+   */
+  public void setServiceName( String serviceName ) {
+    this.serviceName = serviceName;
+  }
+
+  /**
+   * @return the havingCondition
+   */
+  public SQLCondition getHavingCondition() {
+    return havingCondition;
+  }
+
+  /**
+   * @param havingCondition
+   *          the havingCondition to set
+   */
+  public void setHavingCondition( SQLCondition havingCondition ) {
+    this.havingCondition = havingCondition;
+  }
+
+  /**
+   * @return the namespace
+   */
+  public String getNamespace() {
+    return namespace;
+  }
+
+}

--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLAggregation.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLAggregation.java
@@ -1,0 +1,37 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.sql;
+
+public enum SQLAggregation {
+  SUM( "SUM" ), AVG( "AVG" ), MIN( "MIN" ), MAX( "MAX" ), COUNT( "COUNT" );
+
+  private String keyWord;
+
+  private SQLAggregation( String keyWord ) {
+    this.keyWord = keyWord;
+  }
+
+  public String getKeyWord() {
+    return keyWord;
+  }
+}

--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLCondition.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLCondition.java
@@ -1,0 +1,508 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.sql;
+
+import org.pentaho.di.core.Condition;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleSQLException;
+import org.pentaho.di.core.jdbc.ThinUtil;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaAndData;
+import org.pentaho.di.core.row.value.ValueMetaString;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SQLCondition {
+
+  private String tableAlias;
+  RowMetaInterface serviceFields;
+  private Condition condition;
+  private String conditionClause;
+  private SQLFields selectFields;
+
+  private static final Pattern
+      PARAMETER_REGEX_PATTERN =
+      Pattern.compile( "(?i)^PARAMETER\\s*\\(\\s*'(.*)'\\s*\\)\\s*=\\s*'?([^']*)'?$" );
+
+  public SQLCondition( String tableAlias, String conditionSql, RowMetaInterface serviceFields )
+      throws KettleSQLException {
+    this( tableAlias, conditionSql, serviceFields, null );
+  }
+
+  public SQLCondition( String tableAlias, String conditionSql, RowMetaInterface serviceFields, SQLFields selectFields )
+      throws KettleSQLException {
+    this.tableAlias = tableAlias;
+    this.conditionClause = conditionSql;
+    this.serviceFields = serviceFields;
+    this.selectFields = selectFields;
+
+    parse();
+  }
+
+  /**
+   * Support for conditions is very simple for now:
+   * <p/>
+   * <Field> <operator> <value> <Field> <operator> <other field>
+   * <p/>
+   * TODO: figure out a simple algorithm to split up on brackets, AND, OR
+   *
+   * @throws KettleSQLException
+   */
+  private void parse() throws KettleSQLException {
+
+    // Split the condition clause on brackets and operators (AND, OR)
+    // Since the Kettle condition simply evaluates without precedence, we'll just
+    // break the clause down into pieces and then define one or more conditions
+    // depending on the number of pieces we found.
+    //
+    condition = splitConditionByOperator( conditionClause, null, Condition.OPERATOR_NONE );
+    for ( int i = 0; i < 20; i++ ) {
+      // Simplify
+      if ( !condition.simplify() ) {
+        break;
+      }
+    }
+  }
+
+  /**
+   * Searches for the given string in a clause and returns the start index if found, -1 if not found. This method skips
+   * brackets and single quotes. Case is ignored
+   *
+   * @param clause     the clause
+   * @param string     the string to search
+   * @param startIndex the index to start searching
+   * @return the index if the string is found, -1 if not found
+   * @throws KettleSQLException
+   */
+  private int searchForString( String clause, String string, int startIndex ) throws KettleSQLException {
+    int index = startIndex;
+    while ( index < clause.length() ) {
+      index = ThinUtil.skipChars( clause, index, '\'', '(' );
+      if ( index + string.length() > clause.length() ) {
+        return -1; // done.
+      }
+      if ( clause.substring( index ).toUpperCase().startsWith( string.toUpperCase() ) ) {
+        return index;
+      }
+      index++;
+    }
+    return -1;
+  }
+
+  private Condition splitConditionByOperator( String clause, Condition parentCondition, int parentOperator )
+      throws KettleSQLException {
+    if ( parentCondition == null ) {
+      parentCondition = new Condition();
+    } else {
+      // add a new condition to the list...
+      //
+      Condition c = new Condition();
+      c.setOperator( parentOperator );
+      parentCondition.addCondition( c );
+      parentCondition = c;
+    }
+
+    // First we find bracket pairs, then OR, then AND
+    //
+    // C='foo' AND ( A=5 OR B=6 )
+    // ( A=4 OR B=3 ) AND ( A=5 OR B=6 )
+    // ( clause1 ) AND ( clause2) AND ( clause3 )
+    //
+
+    // First try to split by OR, leaving grouped AND blocks.
+    // e.g. A OR B AND C OR D --> A OR ( B AND C ) OR D --> A, B AND C, D
+    //
+    String orOperatorString = " OR ";
+    int orConditionOperator = Condition.OPERATOR_OR;
+    int lastIndex = splitByOperator( clause, parentCondition, orOperatorString, orConditionOperator );
+    if ( lastIndex == 0 ) {
+
+      // No AND operator(s) found, now we can look for OR operators in the clause...
+      // Try to split by OR
+      //
+      String andOperatorString = " AND ";
+      int andConditionOperator = Condition.OPERATOR_AND;
+      lastIndex = splitByOperator( clause, parentCondition, andOperatorString, andConditionOperator );
+      if ( lastIndex == 0 ) {
+        String cleaned = Const.trim( clause );
+        boolean negation = false;
+
+        // See if it's a PARAMETER
+        //
+        Matcher paramMatcher = PARAMETER_REGEX_PATTERN.matcher( cleaned );
+        if ( paramMatcher.matches() ) {
+          String parameterName = paramMatcher.group( 1 );
+          String parameterValue = paramMatcher.group( 2 );
+
+          validateParam( clause, parameterName, parameterValue );
+
+          parentCondition
+              .addCondition( createParameterCondition( orConditionOperator, parameterName, parameterValue ) );
+        } else {
+
+          // See if this elementary block is a NOT ( ) construct
+          //
+          if ( Pattern.matches( "^NOT\\s*\\(.*\\)$", cleaned.toUpperCase() ) ) {
+            negation = true;
+            cleaned = Const.trim( cleaned.substring( 3 ) );
+          }
+
+          // No AND or OR operators found,
+          // First remove possible brackets though
+          //
+          if ( cleaned.startsWith( "(" ) && cleaned.endsWith( ")" ) ) {
+            // Brackets are skipped above so we add a new condition to the list, and remove the brackets
+            //
+            cleaned = cleaned.substring( 1, cleaned.length() - 1 );
+            Condition c = splitConditionByOperator( cleaned, parentCondition, Condition.OPERATOR_NONE );
+            c.setNegated( negation );
+
+          } else {
+
+            // Atomic condition
+            //
+            Condition subCondition = parseAtomicCondition( cleaned );
+            subCondition.setOperator( orConditionOperator );
+            parentCondition.addCondition( subCondition );
+          }
+        }
+      }
+    }
+
+    return parentCondition;
+  }
+
+  /**
+   * Creates a Condition object which will act as a container for a Parameter key/value.
+   */
+  private Condition createParameterCondition( int orConditionOperator, String parameterName, String parameterValue ) {
+    Condition
+        subCondition =
+        new Condition( parameterName, Condition.FUNC_TRUE, parameterName,
+            new ValueMetaAndData( new ValueMetaString( "string" ),
+                Const.NVL( parameterValue, "" ) ) );
+    subCondition.setOperator( orConditionOperator );
+    return subCondition;
+  }
+
+  private void validateParam( String clause, String parameterName, String parameterValue ) throws KettleSQLException {
+    if ( Const.isEmpty( parameterName ) ) {
+      throw new KettleSQLException( "A parameter name cannot be empty in : " + clause );
+    }
+    if ( Const.isEmpty( parameterValue ) || parameterValue.equals( "''" ) ) {
+      throw new KettleSQLException( "A parameter value cannot be empty in : " + clause );
+    }
+  }
+
+  private int splitByOperator( String clause, Condition parentCondition, String operatorString, int conditionOperator )
+      throws KettleSQLException {
+    int lastIndex = 0;
+    int index = 0;
+    while ( index < clause.length() && ( index = searchForString( clause, operatorString, index ) ) >= 0 ) {
+      // Split on the index --> ( clause1 ), ( clause2), (clause 3)
+      //
+      String left = clause.substring( lastIndex, index );
+      splitConditionByOperator( left, parentCondition, conditionOperator );
+      index += operatorString.length();
+      lastIndex = index;
+    }
+
+    // let's not forget to split the last right part or the OR(s)
+    //
+    if ( lastIndex > 0 ) {
+      String right = clause.substring( lastIndex );
+      splitConditionByOperator( right, parentCondition, conditionOperator );
+    }
+
+    return lastIndex;
+  }
+
+  private Condition parseAtomicCondition( String clause ) throws KettleSQLException {
+    // First split on spaces...
+    //
+    List<String> strings = splitConditionClause( clause );
+    if ( strings.size() > 3 ) {
+      throw new KettleSQLException(
+          "Unfortunately support for conditions is still very rudimentary, only 1 simple condition is supported ["
+              + clause + "]" );
+    }
+    String left = "";
+    try {
+      left = strings.get( 0 );
+    } catch ( Exception e ) {
+      throw new KettleSQLException( "Invalid SQL statement [" + clause + "]" );
+    }
+
+
+    // See if this is not a having clause expression :
+    // example:
+    //
+    // SELECT country, count(distinct id) as customerCount FROM service GROUP BY country HAVING count(distinct id) > 10
+    //
+    if ( selectFields != null ) {
+      for ( SQLField field : selectFields.getFields() ) {
+        if ( field.getExpression().equalsIgnoreCase( left ) ) {
+          if ( !Const.isEmpty( field.getAlias() ) ) {
+            left = field.getAlias();
+          }
+          break;
+        }
+      }
+    }
+
+    // Remove the optional table alias prefix from the left field
+    //
+    left = ThinUtil.resolveFieldName( ThinUtil.stripQuoteTableAlias( left, tableAlias ),
+      getServiceFields() );
+    String operatorString = strings.get( 1 );
+    String right = strings.get( 2 );
+
+    // If it's another column name, remove possible table alias prefix.
+    //
+    right = ThinUtil.resolveFieldName( ThinUtil.stripQuoteTableAlias( right, tableAlias ),
+      getServiceFields() );
+
+    ValueMetaAndData value = null;
+
+    int function = Condition.getFunction( operatorString );
+    if ( function == Condition.FUNC_IN_LIST ) {
+      // lose the brackets
+      //
+      String trimmed = Const.trim( right );
+      String partClause = trimmed.substring( 1, trimmed.length() - 1 );
+      List<String> parts = ThinUtil.splitClause( partClause, ',', '\'' );
+      StringBuilder valueString = new StringBuilder();
+      for ( String part : parts ) {
+        if ( valueString.length() > 0 ) {
+          valueString.append( ";" );
+        }
+
+        part = Const.trim( part );
+
+        // Remove the quotes around the string...
+        //
+        if ( part.startsWith( "'" ) && part.endsWith( "'" ) ) {
+          part = part.substring( 1, part.length() - 1 );
+        }
+
+        // Undo escaping...
+        //
+        part = part.replace( "''", "'" );
+
+        // Escape semi-colons
+        //
+        part = part.replace( ";", "\\;" );
+
+        valueString.append( part );
+      }
+      value =
+          new ValueMetaAndData( new ValueMetaString( "constant-in-list" ), valueString.toString() );
+    } else {
+
+      // Mondrian, analyzer CONTAINS hack:
+      // '%' || 'string' || '%' --> '%string%'
+      //
+      String prefix = "'%'";
+      String suffix = "'%'";
+      if ( right.startsWith( prefix ) && right.endsWith( suffix ) ) {
+        int leftOrIndex = right.indexOf( "||" );
+        if ( leftOrIndex > 0 ) {
+          int rightOrIndex = right.indexOf( "||", leftOrIndex + 2 );
+          if ( rightOrIndex > 0 ) {
+            String raw = Const.trim( right.substring( leftOrIndex + 2, rightOrIndex ) );
+            if ( raw.startsWith( "'" ) && raw.endsWith( "'" ) ) {
+              right = "'%" + raw.substring( 1, raw.length() - 1 ) + "%'";
+            }
+
+          }
+        }
+
+      }
+
+      value = ThinUtil.extractConstant( right );
+    }
+
+    if ( value != null ) {
+      return new Condition( left, function, null, value );
+    } else {
+      return new Condition( left, function, right, null );
+    }
+  }
+
+
+  /**
+   * We need to split conditions on a single operator (for now)
+   *
+   * @param clause
+   * @return 3 string list (left, operator, right)
+   * @throws KettleSQLException
+   */
+  private List<String> splitConditionClause( String clause ) throws KettleSQLException {
+    List<String> strings = new ArrayList<String>();
+
+    String[]
+      operators =
+      new String[] { "<>", ">=", "=>", "<=", "=<", "<", ">", "=", " REGEX ", " IN ", " IS NOT NULL", " IS NULL",
+        " LIKE", "CONTAINS " };
+    int[]
+      functions =
+      new int[] { Condition.FUNC_NOT_EQUAL, Condition.FUNC_LARGER_EQUAL, Condition.FUNC_LARGER_EQUAL,
+        Condition.FUNC_SMALLER_EQUAL, Condition.FUNC_SMALLER_EQUAL, Condition.FUNC_SMALLER, Condition.FUNC_LARGER,
+        Condition.FUNC_EQUAL, Condition.FUNC_REGEXP, Condition.FUNC_IN_LIST, Condition.FUNC_NOT_NULL,
+        Condition.FUNC_NULL, Condition.FUNC_LIKE, Condition.FUNC_CONTAINS, };
+    int index = 0;
+    while ( index < clause.length() ) {
+      index = ThinUtil.skipChars( clause, index, '\'', '"' );
+      for ( String operator : operators ) {
+        if ( index <= clause.length() - operator.length() ) {
+          if ( clause.substring( index ).toUpperCase().startsWith( operator ) ) {
+            int functionIndex = Const.indexOfString( operator, operators );
+
+            // OK, we found an operator.
+            // The part before is the first string
+            //
+            String left = Const.trim( clause.substring( 0, index ) );
+            String op = Condition.functions[functions[functionIndex]];
+            String right = Const.trim( clause.substring( index + operator.length() ) );
+            strings.add( left );
+            strings.add( op );
+            strings.add( right );
+            return strings;
+          }
+        }
+      }
+      index++;
+    }
+
+    return strings;
+  }
+
+  /**
+   * @return the serviceFields
+   */
+  public RowMetaInterface getServiceFields() {
+    return serviceFields;
+  }
+
+  /**
+   * @param serviceFields the serviceFields to set
+   */
+  public void setServiceFields( RowMetaInterface serviceFields ) {
+    this.serviceFields = serviceFields;
+  }
+
+  /**
+   * @return the condition
+   */
+  public Condition getCondition() {
+    return condition;
+  }
+
+  /**
+   * @param condition the condition to set
+   */
+  public void setCondition( Condition condition ) {
+    this.condition = condition;
+  }
+
+  /**
+   * @return the conditionClause
+   */
+  public String getConditionClause() {
+    return conditionClause;
+  }
+
+  /**
+   * @param conditionClause the conditionClause to set
+   */
+  public void setConditionClause( String conditionClause ) {
+    this.conditionClause = conditionClause;
+  }
+
+  public boolean isEmpty() {
+    return condition.isEmpty();
+  }
+
+  /**
+   * @return the selectFields
+   */
+  public SQLFields getSelectFields() {
+    return selectFields;
+  }
+
+  /**
+   * @return the tableAlias
+   */
+  public String getTableAlias() {
+    return tableAlias;
+  }
+
+  /**
+   * Extract the list of having fields from this having condition
+   *
+   * @param aggFields
+   * @param rowMeta
+   * @return
+   * @throws KettleSQLException
+   */
+  public List<SQLField> extractHavingFields( List<SQLField> selectFields, List<SQLField> aggFields,
+      RowMetaInterface rowMeta ) throws KettleSQLException {
+    List<SQLField> list = new ArrayList<SQLField>();
+
+    // Get a list of all the lowest level field names and see if we can parse them as aggregation fields
+    //
+    List<String> expressions = new ArrayList<String>();
+    addExpressions( condition, expressions );
+
+    for ( String expression : expressions ) {
+      // See if we already specified the aggregation in the Select clause, let's aggregate twice.
+      //
+      SQLField aggField = SQLField.searchSQLFieldByFieldOrAlias( aggFields, expression );
+      if ( aggField == null ) {
+
+        SQLField field = new SQLField( tableAlias, expression, serviceFields );
+        if ( field.getAggregation() != null ) {
+          field.setField( expression );
+          list.add( field );
+        }
+      }
+    }
+
+    return list;
+  }
+
+  private void addExpressions( Condition condition, List<String> expressions ) {
+    if ( condition.isAtomic() ) {
+      if ( !expressions.contains( condition.getLeftValuename() ) ) {
+        expressions.add( condition.getLeftValuename() );
+      }
+    } else {
+      for ( Condition child : condition.getChildren() ) {
+        addExpressions( child, expressions );
+      }
+    }
+  }
+}

--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLField.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLField.java
@@ -1,0 +1,496 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.sql;
+
+import java.util.List;
+
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleSQLException;
+import org.pentaho.di.core.jdbc.ThinUtil;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.ValueMetaAndData;
+import org.pentaho.di.core.row.ValueMetaInterface;
+
+public class SQLField {
+  private String tableAlias;
+  private String field;
+  private String alias;
+  private SQLAggregation aggregation;
+  private ValueMetaInterface valueMeta;
+  private boolean countStar;
+  private boolean countDistinct;
+  private boolean orderField;
+  private boolean ascending;
+  private String expression;
+  private SQLFields selectFields;
+  private Object valueData;
+
+  /** IIF function hack */
+  private IifFunction iif;
+
+  /** To easily figure out to which index in the select this field belongs */
+  private int fieldIndex;
+
+  /**
+   * @param field
+   * @param alias
+   * @param aggregation
+   * @param valueMeta
+   */
+  public SQLField( String tableAlias, String field, String alias, SQLAggregation aggregation,
+    ValueMetaInterface valueMeta ) {
+    this.tableAlias = tableAlias;
+    this.field = field;
+    this.alias = alias;
+    this.aggregation = aggregation;
+    this.valueMeta = valueMeta;
+  }
+
+  public SQLField( String tableAlias, String fieldClause, RowMetaInterface serviceFields ) throws KettleSQLException {
+    this( tableAlias, fieldClause, serviceFields, false );
+  }
+
+  public SQLField( String tableAlias, String fieldClause, RowMetaInterface serviceFields, boolean orderField ) throws KettleSQLException {
+    this( tableAlias, fieldClause, serviceFields, orderField, null );
+  }
+
+  public SQLField( String tableAlias, String fieldClause, RowMetaInterface serviceFields, boolean orderField,
+    SQLFields selectFields ) throws KettleSQLException {
+    this.tableAlias = tableAlias;
+    this.orderField = orderField;
+    this.selectFields = selectFields;
+
+    // The field clause is in the form: <field or aggregate> [as] [alias]
+    // Fields can be quoted with "
+    //
+    List<String> strings = ThinUtil.splitClause( fieldClause, ' ', '"', '(' );
+
+    if ( strings.size() == 0 ) {
+      throw new KettleSQLException( "Unable to find a valid field" );
+    }
+
+    if ( strings.size() >= 1 ) {
+      String value = strings.get( 0 );
+      field = ThinUtil.stripQuoteTableAlias( value, tableAlias );
+      expression = field;
+
+      if ( orderField ) {
+        if ( strings.size() > 2 ) {
+          throw new KettleSQLException( "Too many elements for an ORDER BY argument: [" + fieldClause + "]" );
+        }
+        if ( strings.size() == 2 ) {
+          String ascDesc = strings.get( 1 );
+          if ( "ASC".equalsIgnoreCase( ascDesc ) ) {
+            ascending = true;
+          } else if ( "DESC".equalsIgnoreCase( ascDesc ) ) {
+            ascending = false;
+          } else {
+            throw new KettleSQLException( "Unable to recognize sort order [" + ascDesc + "]" );
+          }
+        } else {
+          ascending = true;
+        }
+      } else {
+
+        // see if it's an aggregate like SUM( foo )
+        //
+        for ( SQLAggregation agg : SQLAggregation.values() ) {
+          if ( value.toUpperCase().startsWith( agg.getKeyWord() + "(" ) ) {
+            aggregation = agg;
+            // also determine the field..;
+            //
+            int openIndex = value.indexOf( '(', agg.getKeyWord().length() );
+            if ( openIndex < 0 ) {
+              throw new KettleSQLException( "No opening bracket found after keyword ["
+                + aggregation.getKeyWord() + "] in clause [" + fieldClause + "]" );
+            }
+            int closeIndex = value.indexOf( ')', openIndex );
+            if ( closeIndex < 0 ) {
+              throw new KettleSQLException( "No closing bracket found after keyword ["
+                + aggregation.getKeyWord() + "]" );
+            }
+            field = ThinUtil.stripQuotes( Const.trim( value.substring( openIndex + 1, closeIndex ) ), '"' );
+            field = ThinUtil.stripQuoteTableAlias( field, tableAlias );
+            break;
+          }
+        }
+
+        if ( SQLAggregation.COUNT == aggregation ) {
+
+          // COUNT(*)
+          //
+          if ( "*".equals( field ) ) {
+            countStar = true;
+          }
+
+          // COUNT(DISTINCT foo)
+          //
+          if ( field.toUpperCase().startsWith( "DISTINCT " ) ) {
+            int firstSpaceIndex = field.indexOf( ' ' );
+            field = field.substring( firstSpaceIndex + 1 );
+            field = ThinUtil.stripQuoteTableAlias( field, tableAlias );
+
+            countDistinct = true;
+          }
+
+          alias = Const.NVL( alias, expression );
+
+        }
+
+        if ( strings.size() == 2 ) {
+          alias = ThinUtil.stripQuotes( Const.trim( strings.get( 1 ) ), '"' );
+        }
+        // Uses the "AS" word in between
+        if ( strings.size() == 3 ) {
+          if ( !"as".equalsIgnoreCase( strings.get( 1 ) ) ) {
+            throw new KettleSQLException( "AS keyword expected between the field and the alias in field clause: ["
+              + fieldClause + "]" );
+          }
+          alias = ThinUtil.stripQuotes( Const.trim( strings.get( 2 ) ), '"' );
+        }
+      }
+    }
+
+    if ( !countStar ) {
+      if ( orderField ) {
+        // For order by fields we need to see what the expression was in the select clause
+        //
+        for ( SQLField selectField : selectFields.getFields() ) {
+          if ( selectField.getExpression().equalsIgnoreCase( field ) ) {
+            if ( selectField.getAggregation() != null ) {
+
+              switch ( selectField.getAggregation() ) {
+                case COUNT:
+                  valueMeta = new ValueMeta( field, ValueMetaInterface.TYPE_INTEGER, 15 );
+                  break;
+                case MIN:
+                case MAX:
+                case AVG:
+                case SUM:
+                  valueMeta = selectField.getValueMeta();
+                  break;
+                default:
+                  break;
+              }
+              alias = selectField.getAlias();
+
+            } else {
+              // regular field but grab the new name if any, we need it during generation
+              //
+              field = selectField.getField();
+              alias = selectField.getAlias();
+            }
+          }
+        }
+      }
+
+      // See if the field is a function...
+      // TODO: make generic, for now keep it simple
+      //
+      if ( field.startsWith( "IIF(" ) ) {
+        String arguments = field.substring( 4, field.length() - 1 ); // skip the closing bracket too
+        List<String> argsList = ThinUtil.splitClause( arguments, ',', '\'', '(' );
+        if ( argsList.size() != 3 ) {
+          throw new KettleSQLException( "The IIF function requires exactly 3 arguments" );
+        }
+        iif =
+          new IifFunction( tableAlias, Const.trim( argsList.get( 0 ) ), Const.trim( argsList.get( 1 ) ), Const
+            .trim( argsList.get( 2 ) ), serviceFields );
+
+      } else if ( field.toUpperCase().startsWith( "CASE WHEN " ) && field.toUpperCase().endsWith( "END" ) ) {
+        // Same as IIF but with a different format.
+        //
+        String condition = Const.trim( ThinUtil.findClause( field, "WHEN", "THEN" ) );
+        String trueClause = Const.trim( ThinUtil.findClause( field, "THEN", "ELSE" ) );
+        String falseClause = Const.trim( ThinUtil.findClause( field, "ELSE", "END" ) );
+        iif = new IifFunction( tableAlias, condition, trueClause, falseClause, serviceFields );
+
+      } else {
+        if ( valueMeta == null ) {
+          field = ThinUtil.resolveFieldName( field, serviceFields );
+          valueMeta = serviceFields.searchValueMeta( field );
+          if ( orderField && selectFields != null ) {
+            // See if this isn't an aliased select field that we're ordering on
+            //
+            for ( SQLField selectField : selectFields.getFields() ) {
+              if ( field.equalsIgnoreCase( selectField.getAlias() ) ) {
+                valueMeta = selectField.getValueMeta();
+                break;
+              }
+            }
+          }
+        }
+
+        if ( valueMeta == null ) {
+
+          // OK, field is not a service field nor an aggregate, not IIF
+          // See if it's a constant value...
+          //
+          ValueMetaAndData vmad = ThinUtil.extractConstant( field );
+          if ( vmad != null ) {
+            valueMeta = vmad.getValueMeta();
+            valueData = vmad.getValueData();
+          } else {
+            throw new KettleSQLException( "The field with name ["
+              + field + "] could not be found in the service output" );
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * @return the name
+   */
+  public String getName() {
+    return field;
+  }
+
+  /**
+   * @param name
+   *          the name to set
+   */
+  public void setName( String name ) {
+    this.field = name;
+  }
+
+  /**
+   * @return the alias
+   */
+  public String getAlias() {
+    return alias;
+  }
+
+  /**
+   * @param alias
+   *          the alias to set
+   */
+  public void setAlias( String alias ) {
+    this.alias = alias;
+  }
+
+  /**
+   * @return the aggregation
+   */
+  public SQLAggregation getAggregation() {
+    return aggregation;
+  }
+
+  /**
+   * @param aggregation
+   *          the aggregation to set
+   */
+  public void setAggregation( SQLAggregation aggregation ) {
+    this.aggregation = aggregation;
+  }
+
+  /**
+   * @return the valueMeta
+   */
+  public ValueMetaInterface getValueMeta() {
+    return valueMeta;
+  }
+
+  /**
+   * @param valueMeta
+   *          the valueMeta to set
+   */
+  public void setValueMeta( ValueMetaInterface valueMeta ) {
+    this.valueMeta = valueMeta;
+  }
+
+  /**
+   * @return the field
+   */
+  public String getField() {
+    return field;
+  }
+
+  /**
+   * @param field
+   *          the field to set
+   */
+  public void setField( String field ) {
+    this.field = field;
+  }
+
+  /**
+   * @return the countStar
+   */
+  public boolean isCountStar() {
+    return countStar;
+  }
+
+  /**
+   * @param countStar
+   *          the countStar to set
+   */
+  public void setCountStar( boolean countStar ) {
+    this.countStar = countStar;
+  }
+
+  /**
+   * @return the countDistinct
+   */
+  public boolean isCountDistinct() {
+    return countDistinct;
+  }
+
+  /**
+   * @param countDistinct
+   *          the countDistinct to set
+   */
+  public void setCountDistinct( boolean countDistinct ) {
+    this.countDistinct = countDistinct;
+  }
+
+  /**
+   * @return the orderField
+   */
+  public boolean isOrderField() {
+    return orderField;
+  }
+
+  /**
+   * @param orderField
+   *          the orderField to set
+   */
+  public void setOrderField( boolean orderField ) {
+    this.orderField = orderField;
+  }
+
+  /**
+   * @return the ascending
+   */
+  public boolean isAscending() {
+    return ascending;
+  }
+
+  /**
+   * @param ascending
+   *          the ascending to set
+   */
+  public void setAscending( boolean ascending ) {
+    this.ascending = ascending;
+  }
+
+  /**
+   * @return the expression
+   */
+  public String getExpression() {
+    return expression;
+  }
+
+  /**
+   * @param expression
+   *          the expression to set
+   */
+  public void setExpression( String expression ) {
+    this.expression = expression;
+  }
+
+  /**
+   * @return the selectFields
+   */
+  public SQLFields getSelectFields() {
+    return selectFields;
+  }
+
+  /**
+   * @param selectFields
+   *          the selectFields to set
+   */
+  public void setSelectFields( SQLFields selectFields ) {
+    this.selectFields = selectFields;
+  }
+
+  /**
+   * @return the iif
+   */
+  public IifFunction getIif() {
+    return iif;
+  }
+
+  /**
+   * @return the valueData
+   */
+  public Object getValueData() {
+    return valueData;
+  }
+
+  /**
+   * @param valueData
+   *          the valueData to set
+   */
+  public void setValueData( Object valueData ) {
+    this.valueData = valueData;
+  }
+
+  /**
+   * @param iif
+   *          the iif to set
+   */
+  public void setIif( IifFunction iif ) {
+    this.iif = iif;
+  }
+
+  /**
+   * @return the tableAlias
+   */
+  public String getTableAlias() {
+    return tableAlias;
+  }
+
+  /**
+   * @param tableAlias
+   *          the tableAlias to set
+   */
+  public void setTableAlias( String tableAlias ) {
+    this.tableAlias = tableAlias;
+  }
+
+  /**
+   * @return the fieldIndex
+   */
+  public int getFieldIndex() {
+    return fieldIndex;
+  }
+
+  /**
+   * @param fieldIndex
+   *          the fieldIndex to set
+   */
+  public void setFieldIndex( int fieldIndex ) {
+    this.fieldIndex = fieldIndex;
+  }
+
+  public static SQLField searchSQLFieldByFieldOrAlias( List<SQLField> fields, String name ) {
+    for ( SQLField field : fields ) {
+      if ( name.equalsIgnoreCase( field.getField() ) || name.equalsIgnoreCase( field.getAlias() ) ) {
+        return field;
+      }
+    }
+    return null;
+  }
+}

--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLFields.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLFields.java
@@ -1,0 +1,280 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.sql;
+
+import com.google.common.collect.Lists;
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleSQLException;
+import org.pentaho.di.core.jdbc.ThinUtil;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SQLFields {
+  private static final String DISTINCT_PREFIX = "DISTINCT ";
+  private String tableAlias;
+  private RowMetaInterface serviceFields;
+  private String fieldsClause;
+  private List<SQLField> fields;
+  private SQLFields selectFields;
+
+  private boolean distinct;
+
+  public SQLFields( String tableAlias, RowMetaInterface serviceFields, String fieldsClause ) throws KettleSQLException {
+    this( tableAlias, serviceFields, fieldsClause, false );
+  }
+
+  public SQLFields( String tableAlias, RowMetaInterface serviceFields, String fieldsClause, boolean orderClause ) throws KettleSQLException {
+    this( tableAlias, serviceFields, fieldsClause, orderClause, null );
+  }
+
+  public SQLFields( String tableAlias, RowMetaInterface serviceFields, String fieldsClause, boolean orderClause,
+    SQLFields selectFields ) throws KettleSQLException {
+    this.tableAlias = tableAlias;
+    this.serviceFields = serviceFields;
+    this.fieldsClause = fieldsClause;
+    this.selectFields = selectFields;
+    fields = Lists.newArrayList();
+
+    distinct = false;
+
+    parse( orderClause );
+  }
+
+  private void parse( boolean orderClause ) throws KettleSQLException {
+    if ( Const.isEmpty( fieldsClause ) ) {
+      return;
+    }
+
+    if ( fieldsClause.regionMatches( true, 0, DISTINCT_PREFIX, 0, DISTINCT_PREFIX.length() ) ) {
+      distinct = true;
+      fieldsClause = fieldsClause.substring( DISTINCT_PREFIX.length() );
+    }
+
+    List<String> strings = new ArrayList<String>();
+    int startIndex = 0;
+    for ( int index = 0; index < fieldsClause.length(); index++ ) {
+      index = ThinUtil.skipChars( fieldsClause, index, '"', '\'', '(' );
+      if ( index >= fieldsClause.length() ) {
+        strings.add( fieldsClause.substring( startIndex ) );
+        startIndex = -1;
+        break;
+      }
+      if ( fieldsClause.charAt( index ) == ',' ) {
+        strings.add( fieldsClause.substring( startIndex, index ) );
+        startIndex = index + 1;
+      }
+    }
+    if ( startIndex >= 0 ) {
+      strings.add( fieldsClause.substring( startIndex ) );
+    }
+
+    // Now grab all the fields and determine their composition...
+    //
+    fields.clear();
+    for ( String string : strings ) {
+      String fieldString = ThinUtil.stripTableAlias( Const.trim( string ), tableAlias );
+      if ( "*".equals( fieldString ) ) {
+        // Add all service fields
+        //
+        for ( ValueMetaInterface valueMeta : serviceFields.getValueMetaList() ) {
+          fields.add( new SQLField(
+            tableAlias, "\"" + valueMeta.getName() + "\"", serviceFields, orderClause, selectFields ) );
+        }
+      } else {
+        fields.add( new SQLField( tableAlias, fieldString, serviceFields, orderClause, selectFields ) );
+      }
+    }
+
+    indexFields();
+  }
+
+  public List<SQLField> getFields() {
+    return fields;
+  }
+
+  public List<SQLField> getNonAggregateFields() {
+    List<SQLField> list = new ArrayList<SQLField>();
+    for ( SQLField field : fields ) {
+      if ( field.getAggregation() == null ) {
+        list.add( field );
+      }
+    }
+    return list;
+  }
+
+  public List<SQLField> getAggregateFields() {
+    List<SQLField> list = new ArrayList<SQLField>();
+    for ( SQLField field : fields ) {
+      if ( field.getAggregation() != null ) {
+        list.add( field );
+      }
+    }
+    return list;
+  }
+
+  public boolean isEmpty() {
+    return fields.isEmpty();
+  }
+
+  /**
+   * Find a field by it's field name (not alias)
+   *
+   * @param fieldName
+   *          the name of the field
+   * @return the field or null if nothing was found.
+   */
+  public SQLField findByName( String fieldName ) {
+    for ( SQLField field : fields ) {
+      if ( field.getField().equalsIgnoreCase( fieldName ) ) {
+        return field;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * @return the serviceFields
+   */
+  public RowMetaInterface getServiceFields() {
+    return serviceFields;
+  }
+
+  /**
+   * @param serviceFields
+   *          the serviceFields to set
+   */
+  public void setServiceFields( RowMetaInterface serviceFields ) {
+    this.serviceFields = serviceFields;
+  }
+
+  /**
+   * @return the fieldsClause
+   */
+  public String getFieldsClause() {
+    return fieldsClause;
+  }
+
+  /**
+   * @param fieldsClause
+   *          the fieldsClause to set
+   */
+  public void setFieldsClause( String fieldsClause ) {
+    this.fieldsClause = fieldsClause;
+  }
+
+  /**
+   * @return the selectFields
+   */
+  public SQLFields getSelectFields() {
+    return selectFields;
+  }
+
+  /**
+   * @param selectFields
+   *          the selectFields to set
+   */
+  public void setSelectFields( SQLFields selectFields ) {
+    this.selectFields = selectFields;
+  }
+
+  /**
+   * @param fields
+   *          the fields to set
+   */
+  public void setFields( List<SQLField> fields ) {
+    this.fields = fields;
+    indexFields();
+  }
+
+  private void indexFields() {
+    for ( int i = 0; i < fields.size(); i++ ) {
+      fields.get( i ).setFieldIndex( i );
+    }
+  }
+
+  /**
+   * @return true if one or more fields is an aggregation.
+   */
+  public boolean hasAggregates() {
+    for ( SQLField field : fields ) {
+      if ( field.getAggregation() != null ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public List<SQLField> getIifFunctionFields() {
+    List<SQLField> list = new ArrayList<SQLField>();
+
+    for ( SQLField field : fields ) {
+      if ( field.getIif() != null ) {
+        list.add( field );
+      }
+    }
+
+    return list;
+  }
+
+  public List<SQLField> getRegularFields() {
+    List<SQLField> list = new ArrayList<SQLField>();
+
+    for ( SQLField field : fields ) {
+      if ( field.getIif() == null && field.getAggregation() == null && field.getValueData() == null ) {
+        list.add( field );
+      }
+    }
+
+    return list;
+  }
+
+  public List<SQLField> getConstantFields() {
+    List<SQLField> list = new ArrayList<SQLField>();
+
+    for ( SQLField field : fields ) {
+      if ( field.getValueMeta() != null && field.getValueData() != null ) {
+        list.add( field );
+      }
+    }
+
+    return list;
+  }
+
+  /**
+   * @return the distinct
+   */
+  public boolean isDistinct() {
+    return distinct;
+  }
+
+  /**
+   * @return the tableAlias
+   */
+  public String getTableAlias() {
+    return tableAlias;
+  }
+
+}

--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLLimit.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLLimit.java
@@ -1,0 +1,105 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.sql;
+
+import org.pentaho.di.core.Const;
+import org.pentaho.di.core.exception.KettleSQLException;
+
+public class SQLLimit {
+
+  private String limitClause;
+
+  private int limit;
+  private int offset;
+
+  public SQLLimit( String limitClause ) throws KettleSQLException {
+    this.limitClause = limitClause;
+
+    parse();
+  }
+
+  /**
+   *
+   * @return The limit of rows to return
+   */
+  public int getLimit() {
+    return limit;
+  }
+
+  /**
+   *
+   * @param limit The limit of rows to return
+   */
+  public void setLimit( int limit ) {
+    this.limit = limit;
+  }
+
+  /**
+   *
+   * @return The offset of the rows to return
+   */
+  public int getOffset() {
+    return offset;
+  }
+
+  /**
+   *
+   * @param offset The offset of the rows to return
+   */
+  public void setOffset( int offset ) {
+    this.offset = offset;
+  }
+
+  private void parse() throws KettleSQLException {
+    if ( Const.isEmpty( limitClause ) ) {
+      return;
+    }
+
+    limitClause = limitClause.replaceAll( "\\s+", " " );
+
+    if ( limitClause.contains( "," ) ) {
+      String[] limitSplit = limitClause.split( "," );
+      if ( limitSplit.length == 2 ) {
+        offset = Integer.valueOf( limitSplit[ 0 ].trim() );
+        limit = Integer.valueOf( limitSplit[ 1 ].trim() );
+      }
+      return;
+    }
+
+    if ( limitClause.toUpperCase().contains( "OFFSET" ) ) {
+      String[] limitSplit = limitClause.split( " " );
+      if ( limitSplit.length == 3 ) {
+        offset = Integer.valueOf( limitSplit[ 2 ].trim() );
+        limit = Integer.valueOf( limitSplit[ 0 ].trim() );
+      }
+      return;
+    }
+
+    try {
+      limit = Integer.valueOf( limitClause.trim() );
+      offset = 0;
+    } catch ( NumberFormatException nfe ) {
+      throw new KettleSQLException( "Invalid limit parameter in : " + limitClause );
+    }
+  }
+}

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/core/jdbc/SQLTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/core/jdbc/SQLTest.java
@@ -1,0 +1,105 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+import org.pentaho.di.core.exception.KettleSQLException;
+import org.pentaho.di.core.sql.SQL;
+
+public class SQLTest {
+  @Test
+  public void testExample1() throws KettleSQLException {
+    String select = "A, B, C";
+    String from = "Step";
+    SQL sql = new SQL( "SELECT " + select + " FROM " + from );
+    assertEquals( select, sql.getSelectClause() );
+    assertEquals( from, sql.getServiceName() );
+    assertNull( sql.getWhereClause() );
+    assertNull( sql.getGroupClause() );
+    assertNull( sql.getHavingClause() );
+    assertNull( sql.getOrderClause() );
+  }
+
+  @Test
+  public void testExample2() throws KettleSQLException {
+    String select = "A, B, C";
+    String from = "Step";
+    String where = "D > 6 AND E = 'abcd'";
+    SQL sql = new SQL( "SELECT " + select + " FROM " + from + " WHERE " + where );
+    assertEquals( select, sql.getSelectClause() );
+    assertEquals( from, sql.getServiceName() );
+    assertEquals( where, sql.getWhereClause() );
+    assertNull( sql.getGroupClause() );
+    assertNull( sql.getHavingClause() );
+    assertNull( sql.getOrderClause() );
+  }
+
+  @Test
+  public void testExample3() throws KettleSQLException {
+    String select = "A, B, C";
+    String from = "Step";
+    String order = "B, A, C";
+    SQL sql = new SQL( "SELECT " + select + " FROM " + from + " ORDER BY " + order );
+    assertEquals( select, sql.getSelectClause() );
+    assertEquals( from, sql.getServiceName() );
+    assertNull( sql.getWhereClause() );
+    assertNull( sql.getGroupClause() );
+    assertNull( sql.getHavingClause() );
+    assertEquals( order, sql.getOrderClause() );
+  }
+
+  @Test
+  public void testExample4() throws KettleSQLException {
+    String select = "A, B, sum(C)";
+    String from = "Step";
+    String where = "D > 6 AND E = 'abcd'";
+    String group = "A, B";
+    String having = "sum(C) > 100";
+    String order = "sum(C) DESC";
+    SQL sql =
+        new SQL( "SELECT " + select + " FROM " + from + " WHERE " + where + " GROUP BY " + group + " HAVING " + having
+            + " ORDER BY " + order );
+    assertEquals( select, sql.getSelectClause() );
+    assertEquals( from, sql.getServiceName() );
+    assertEquals( where, sql.getWhereClause() );
+    assertEquals( group, sql.getGroupClause() );
+    assertEquals( having, sql.getHavingClause() );
+    assertEquals( order, sql.getOrderClause() );
+  }
+
+  @Test
+  public void testWhereInColumnIndexPDI12347() throws KettleSQLException {
+    String select = "whereDoYouLive, good, fine";
+    String from = "testingABC";
+    SQL sql = new SQL( "SELECT " + select + " FROM " + from );
+    assertEquals( select, sql.getSelectClause() );
+    assertEquals( from, sql.getServiceName() );
+    assertNull( sql.getWhereClause() );
+    assertNull( sql.getGroupClause() );
+    assertNull( sql.getHavingClause() );
+    assertNull( sql.getOrderClause() );
+  }
+}

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/core/jdbc/ThinUtilTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/core/jdbc/ThinUtilTest.java
@@ -1,0 +1,328 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.jdbc;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+import org.pentaho.di.core.exception.KettleSQLException;
+import org.pentaho.di.core.exception.KettleValueException;
+import org.pentaho.di.core.row.ValueMetaAndData;
+import org.pentaho.di.core.row.ValueMetaInterface;
+
+import java.math.BigDecimal;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ThinUtilTest {
+  @SuppressWarnings( "deprecation" )
+  @Test
+  public void testFindClauseNullOrEmptyString() throws KettleSQLException {
+    assertNull( ThinUtil.findClause( null, null ) );
+    assertNull( ThinUtil.findClause( "", null ) );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Test
+  public void testFindSelectFromNotFound() throws KettleSQLException {
+    assertNull( ThinUtil.findClause( "Select * From Test", "WHERE" ) );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Test
+  public void testFindSelectFromFound() throws KettleSQLException {
+    assertEquals( "*", ThinUtil.findClause( "Select * From Test", "SELECT", "FROM" ) );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Test
+  public void testFindClauseSkipsChars() throws KettleSQLException {
+    assertNull( ThinUtil.findClause( "'Select' * From Test", "SELECT", "FROM" ) );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Test
+  public void testAttemptDateValueExtraction() throws Exception {
+    ValueMetaAndData timestamp = ThinUtil.attemptDateValueExtraction( "TIMESTAMP '2014-01-01 00:00:00'" );
+    ValueMetaAndData date = ThinUtil.attemptDateValueExtraction( "DATE '2014-01-01'" );
+
+    assertNotNull( timestamp );
+    assertEquals( "2014-01-01 00:00:00", timestamp.toString() );
+
+    assertNotNull( date );
+    assertEquals( "2014-01-01", date.toString() );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Test
+  public void testLikePatternMatching() {
+    try {
+      ThinUtil.like( "foo", null );
+      fail( "Null pattern should not be allowed" );
+    } catch ( IllegalArgumentException e ) {
+      assertNotNull( e );
+    }
+
+    assertTrue( "Exact Matching", ThinUtil.like( "foobar", "foobar" ) );
+
+    assertTrue( "_ Matching", ThinUtil.like( "foobar", "f__b_r" ) );
+    assertTrue( "* Matching", ThinUtil.like( "foobar", "foo%" ) );
+
+    assertTrue( "Regex Escaping", ThinUtil.like( "foo\\*?[]()bar", "%\\*?[]()%" ) );
+
+    assertFalse( "False Match", ThinUtil.like( "foo", "bar" ) );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Test
+  public void testGetValueMeta() throws SQLException {
+    ValueMetaInterface testValue;
+    String expectedName = "testName";
+    testValue = ThinUtil.getValueMeta( expectedName, Types.BIGINT );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.INTEGER );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.SMALLINT );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.CHAR );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.VARCHAR );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.CLOB );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.DATE );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_DATE, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.TIMESTAMP );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_DATE, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.TIME );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_DATE, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.DECIMAL );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_BIGNUMBER, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.DOUBLE );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.FLOAT );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.BOOLEAN );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_BOOLEAN, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.BIT );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_BOOLEAN, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.BINARY );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_BINARY, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.BLOB );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_BINARY, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.OTHER );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_NONE, testValue.getType() );
+
+    testValue = ThinUtil.getValueMeta( expectedName, Types.NULL );
+    assertEquals( expectedName, testValue.getName() );
+    assertEquals( ValueMetaInterface.TYPE_NONE, testValue.getType() );
+
+    try {
+      ThinUtil.getValueMeta( expectedName, Integer.MIN_VALUE );
+      fail();
+    } catch ( SQLException expected ) {
+      // Do nothing, there is no SQL Type for Integer.MIN_VALUE, an exception was thrown as expected.
+    }
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Test
+  public void checkValueMetaTypeToSqlTypeConsistency() throws SQLException {
+    class TypeMap {
+      ValueMetaInterface valueMeta;
+      int sqlType;
+      String sqlDesc;
+      TypeMap( int valueMetaType, int sqlType, String desc ) {
+        this.valueMeta = mock( ValueMetaInterface.class );
+        when( valueMeta.getType() ).thenReturn( valueMetaType );
+        this.sqlType = sqlType;
+        this.sqlDesc = desc;
+      }
+    }
+    TypeMap[] typeMaps = new TypeMap[] {
+      new TypeMap( ValueMetaInterface.TYPE_STRING,    Types.VARCHAR,   "VARCHAR" ),
+      new TypeMap( ValueMetaInterface.TYPE_DATE,      Types.TIMESTAMP, "TIMESTAMP" ),
+      new TypeMap( ValueMetaInterface.TYPE_INTEGER,   Types.BIGINT,    "BIGINT" ),
+      new TypeMap( ValueMetaInterface.TYPE_NUMBER,    Types.DOUBLE,    "DOUBLE" ),
+      new TypeMap( ValueMetaInterface.TYPE_BIGNUMBER, Types.DECIMAL,   "DECIMAL" ),
+      new TypeMap( ValueMetaInterface.TYPE_BOOLEAN,   Types.BOOLEAN,   "BOOLEAN" ),
+      new TypeMap( ValueMetaInterface.TYPE_BINARY,    Types.BLOB,      "BLOB" ),
+      new TypeMap( ValueMetaInterface.TYPE_NONE,      Types.OTHER,     "OTHER" ),
+    };
+    for ( TypeMap map : typeMaps ) {
+      assertEquals( map.sqlDesc, ThinUtil.getSqlTypeDesc( map.valueMeta ) );
+      assertEquals( map.sqlType, ThinUtil.getSqlType( map.valueMeta ) );
+      assertEquals( map.valueMeta.getType(), ThinUtil.getValueMeta( "test", map.sqlType ).getType() );
+    }
+  }
+
+
+  @SuppressWarnings( "deprecation" )
+  @Test
+  public void testAttemptDateValueExtraction2() throws KettleValueException {
+    ValueMetaAndData result = ThinUtil.attemptDateValueExtraction( "[2015/01/02 03:04:56.789]" );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_DATE, result.getValueMeta().getType() );
+    assertEquals( "2015/01/02 03:04:56.789", result.getValueMeta().getString( result.getValueData() ) );
+
+    //assertNull( ThinUtil.attemptDateValueExtraction( null ) );
+    assertNull( ThinUtil.attemptDateValueExtraction( "" ) );
+    assertNull( ThinUtil.attemptDateValueExtraction( "[]" ) );
+    assertNull( ThinUtil.attemptDateValueExtraction( "[notadate]" ) );
+    assertNull( ThinUtil.attemptDateValueExtraction( "2015/01/02 03:04:56.789" ) );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Test
+  public void testAttemptIntegerValueExtraction() {
+    ValueMetaAndData result = ThinUtil.attemptIntegerValueExtraction( "12345" );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_INTEGER, result.getValueMeta().getType() );
+    assertEquals( 12345L, result.getValueData() );
+
+    //assertNull( ThinUtil.attemptIntegerValueExtraction( null ) );
+    assertNull( ThinUtil.attemptIntegerValueExtraction( "" ) );
+    assertNull( ThinUtil.attemptIntegerValueExtraction( "123.45" ) );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Test
+  public void testAttemptNumberValueExtraction() {
+    ValueMetaAndData result = ThinUtil.attemptNumberValueExtraction( "12345.678" );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_NUMBER, result.getValueMeta().getType() );
+    assertEquals( 12345.678, result.getValueData() );
+
+    //assertNull( ThinUtil.attemptNumberValueExtraction( null ) );
+    assertNull( ThinUtil.attemptNumberValueExtraction( "" ) );
+    assertNull( ThinUtil.attemptNumberValueExtraction( "abcde" ) );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Test
+  public void testAttemptBigNumberValueExtraction() {
+    ValueMetaAndData result = ThinUtil.attemptBigNumberValueExtraction( "1234567890123456789.0987654321" );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_BIGNUMBER, result.getValueMeta().getType() );
+    assertEquals( new BigDecimal( "1234567890123456789.0987654321" ), result.getValueData() );
+
+    //assertNull( ThinUtil.attemptBigNumberValueExtraction( null ) );
+    assertNull( ThinUtil.attemptBigNumberValueExtraction( "" ) );
+    assertNull( ThinUtil.attemptBigNumberValueExtraction( "abcde" ) );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Test
+  public void testAttemptStringValueExtraction() {
+    ValueMetaAndData result = ThinUtil.attemptStringValueExtraction( "'testValue'" );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_STRING, result.getValueMeta().getType() );
+    assertEquals( "testValue", result.getValueData() );
+
+    result = ThinUtil.attemptStringValueExtraction( "'test\'\'Value'" );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_STRING, result.getValueMeta().getType() );
+    assertEquals( "test\'Value", result.getValueData() );
+
+    //assertNull( ThinUtil.attemptStringValueExtraction( null ) );
+    assertNull( ThinUtil.attemptStringValueExtraction( "" ) );
+    assertNull( ThinUtil.attemptStringValueExtraction( "abcde" ) );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Test
+  public void testAttemptBooleanValueExtraction() {
+    ValueMetaAndData result = ThinUtil.attemptBooleanValueExtraction( "TrUe" );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_BOOLEAN, result.getValueMeta().getType() );
+    assertEquals( Boolean.TRUE, result.getValueData() );
+
+    result = ThinUtil.attemptBooleanValueExtraction( "fAlSe" );
+    assertNotNull( result );
+    assertEquals( ValueMetaInterface.TYPE_BOOLEAN, result.getValueMeta().getType() );
+    assertEquals( Boolean.FALSE, result.getValueData() );
+
+    assertNull( ThinUtil.attemptBooleanValueExtraction( null ) );
+    assertNull( ThinUtil.attemptBooleanValueExtraction( "" ) );
+    assertNull( ThinUtil.attemptBooleanValueExtraction( "abcde" ) );
+  }
+
+  @SuppressWarnings( "deprecation" )
+  @Test
+  public void testStripQuotesIfNoWhitespace() {
+    // map of tests to expected result
+    Map<String, String> testStrings = new ImmutableMap.Builder<String, String>()
+      .put( "\"quotedNospace\"",                   "quotedNospace" )
+      .put( "unquoted",                            "unquoted" )
+      .put( "\"quoted space\"",                    "\"quoted space\"" )
+      .put( "\"field\" \"fieldAlias\"",            "\"field\" \"fieldAlias\"" )
+      .put( "\"field with space\" \"fieldAlias\"", "\"field with space\" \"fieldAlias\"" )
+      .put( "\"field\" AS \"field Alias\"",        "\"field\" AS \"field Alias\"" )
+      .build();
+
+    for ( String test : testStrings.keySet() ) {
+      for ( char quote : new char[] { '\'', '"', '`' } ) {
+        assertEquals(
+          testStrings.get( test ).replace( '"', quote ),
+          ThinUtil.stripQuotesIfNoWhitespace( test.replace( '"', quote ), quote ) );
+      }
+    }
+  }
+}

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/IifFunctionTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/IifFunctionTest.java
@@ -1,0 +1,68 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.sql;
+
+import junit.framework.TestCase;
+
+import org.pentaho.di.core.Condition;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
+
+public class IifFunctionTest extends TestCase {
+  public void testIifFunction01() throws Exception {
+
+    RowMetaInterface serviceFields = generateTestRowMeta();
+
+    String conditionClause = "B>5000";
+    String trueValueString = "'Big'";
+    String falseValueString = "'Small'";
+
+    IifFunction function =
+      new IifFunction( "Service", conditionClause, trueValueString, falseValueString, serviceFields );
+    assertNotNull( function.getSqlCondition() );
+    Condition condition = function.getSqlCondition().getCondition();
+    assertNotNull( condition );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "B", condition.getLeftValuename() );
+    assertEquals( ">", condition.getFunctionDesc() );
+    assertEquals( "5000", condition.getRightExactString() );
+
+    // test the value data type determination
+    //
+    assertNotNull( function.getTrueValue() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, function.getTrueValue().getValueMeta().getType() );
+    assertEquals( "Big", function.getTrueValue().getValueData() );
+    assertNotNull( function.getFalseValue() );
+    assertEquals( ValueMetaInterface.TYPE_STRING, function.getFalseValue().getValueMeta().getType() );
+    assertEquals( "Small", function.getFalseValue().getValueData() );
+  }
+
+  private RowMetaInterface generateTestRowMeta() {
+    RowMetaInterface rowMeta = new RowMeta();
+    rowMeta.addValueMeta( new ValueMeta( "A", ValueMetaInterface.TYPE_STRING, 50 ) );
+    rowMeta.addValueMeta( new ValueMeta( "B", ValueMetaInterface.TYPE_INTEGER, 7 ) );
+    return rowMeta;
+  }
+}

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLConditionTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLConditionTest.java
@@ -1,0 +1,974 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.sql;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.pentaho.di.core.Condition;
+import org.pentaho.di.core.exception.KettleSQLException;
+import org.pentaho.di.core.row.RowMetaInterface;
+
+import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.pentaho.di.core.sql.SQLTest.mockRowMeta;
+
+public class SQLConditionTest extends TestCase {
+
+  public void testCondition01() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "A = 'FOO'";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "A", condition.getLeftValuename() );
+    assertEquals( "=", condition.getFunctionDesc() );
+    assertEquals( "FOO", condition.getRightExactString() );
+  }
+
+  public void testCondition02() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "B > 123";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "B", condition.getLeftValuename() );
+    assertEquals( ">", condition.getFunctionDesc() );
+    assertEquals( "123", condition.getRightExactString() );
+  }
+
+  public void testCondition03() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "B < 123";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "B", condition.getLeftValuename() );
+    assertEquals( "<", condition.getFunctionDesc() );
+    assertEquals( "123", condition.getRightExactString() );
+  }
+
+  public void testCondition04() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "B >= 123";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "B", condition.getLeftValuename() );
+    assertEquals( ">=", condition.getFunctionDesc() );
+    assertEquals( "123", condition.getRightExactString() );
+  }
+
+  public void testCondition05() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "B => 123";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "B", condition.getLeftValuename() );
+    assertEquals( ">=", condition.getFunctionDesc() );
+    assertEquals( "123", condition.getRightExactString() );
+  }
+
+  public void testCondition06() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "B <= 123";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "B", condition.getLeftValuename() );
+    assertEquals( "<=", condition.getFunctionDesc() );
+    assertEquals( "123", condition.getRightExactString() );
+  }
+
+  public void testCondition07() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "B >= 123";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "B", condition.getLeftValuename() );
+    assertEquals( ">=", condition.getFunctionDesc() );
+    assertEquals( "123", condition.getRightExactString() );
+  }
+
+  public void testCondition08() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "B => 123";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "B", condition.getLeftValuename() );
+    assertEquals( ">=", condition.getFunctionDesc() );
+    assertEquals( "123", condition.getRightExactString() );
+  }
+
+  public void testCondition09() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "B <> 123";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "B", condition.getLeftValuename() );
+    assertEquals( "<>", condition.getFunctionDesc() );
+    assertEquals( "123", condition.getRightExactString() );
+  }
+
+  public void testCondition10() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "B IN (1, 2, 3, 4)";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "B", condition.getLeftValuename() );
+    assertEquals( "IN LIST", condition.getFunctionDesc() );
+    assertEquals( "1;2;3;4", condition.getRightExactString() );
+  }
+
+  public void testCondition11() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "A IN ( 'foo' , 'bar' )";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "A", condition.getLeftValuename() );
+    assertEquals( "IN LIST", condition.getFunctionDesc() );
+    assertEquals( "foo;bar", condition.getRightExactString() );
+  }
+
+  public void testCondition12() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "A REGEX 'foo.*bar'";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "A", condition.getLeftValuename() );
+    assertEquals( "REGEXP", condition.getFunctionDesc() );
+    assertEquals( "foo.*bar", condition.getRightExactString() );
+  }
+
+  public void testCondition13() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "A LIKE 'foo%'";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "A", condition.getLeftValuename() );
+    assertEquals( "LIKE", condition.getFunctionDesc() );
+    assertEquals( "foo%", condition.getRightExactString() );
+  }
+
+  public void testCondition14() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "A LIKE 'foo??bar'";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "A", condition.getLeftValuename() );
+    assertEquals( "LIKE", condition.getFunctionDesc() );
+    assertEquals( "foo??bar", condition.getRightExactString() );
+  }
+
+  // Now the more complex AND/OR/NOT situations...
+  //
+  public void testCondition15() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "A='Foo' AND B>5";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertFalse( "Non-atomic condition expected", condition.isAtomic() );
+    assertEquals( 2, condition.nrConditions() );
+
+    Condition one = condition.getCondition( 0 );
+    assertEquals( "A", one.getLeftValuename() );
+    assertEquals( "=", one.getFunctionDesc() );
+    assertEquals( "Foo", one.getRightExactString() );
+
+    Condition two = condition.getCondition( 1 );
+    assertEquals( "B", two.getLeftValuename() );
+    assertEquals( ">", two.getFunctionDesc() );
+    assertEquals( "5", two.getRightExactString() );
+
+    assertEquals( Condition.OPERATOR_AND, two.getOperator() );
+  }
+
+  public void testCondition16() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "( A='Foo' ) AND ( B>5 )";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertFalse( "Non-atomic condition expected", condition.isAtomic() );
+    assertEquals( 2, condition.nrConditions() );
+
+    Condition one = condition.getCondition( 0 );
+    assertEquals( "A", one.getLeftValuename() );
+    assertEquals( "=", one.getFunctionDesc() );
+    assertEquals( "Foo", one.getRightExactString() );
+
+    Condition two = condition.getCondition( 1 );
+    assertEquals( "B", two.getLeftValuename() );
+    assertEquals( ">", two.getFunctionDesc() );
+    assertEquals( "5", two.getRightExactString() );
+
+    assertEquals( Condition.OPERATOR_AND, two.getOperator() );
+  }
+
+  public void testCondition17() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B, C, D";
+    String conditionClause = "A='Foo' AND B>5 AND C='foo' AND D=123";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertFalse( "Non-atomic condition expected", condition.isAtomic() );
+    assertEquals( 4, condition.nrConditions() );
+
+    Condition one = condition.getCondition( 0 );
+    assertEquals( "A", one.getLeftValuename() );
+    assertEquals( "=", one.getFunctionDesc() );
+    assertEquals( "Foo", one.getRightExactString() );
+
+    Condition two = condition.getCondition( 1 );
+    assertEquals( "B", two.getLeftValuename() );
+    assertEquals( ">", two.getFunctionDesc() );
+    assertEquals( "5", two.getRightExactString() );
+    assertEquals( Condition.OPERATOR_AND, two.getOperator() );
+
+    Condition three = condition.getCondition( 2 );
+    assertEquals( "C", three.getLeftValuename() );
+    assertEquals( "=", three.getFunctionDesc() );
+    assertEquals( "foo", three.getRightExactString() );
+    assertEquals( Condition.OPERATOR_AND, three.getOperator() );
+
+    Condition four = condition.getCondition( 3 );
+    assertEquals( "D", four.getLeftValuename() );
+    assertEquals( "=", four.getFunctionDesc() );
+    assertEquals( "123", four.getRightExactString() );
+    assertEquals( Condition.OPERATOR_AND, four.getOperator() );
+
+  }
+
+  /**
+   * Test precedence.
+   *
+   * @throws KettleSQLException
+   */
+  public void testCondition18() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B, C, D";
+    String conditionClause = "A='Foo' OR B>5 AND C='foo' OR D=123";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertFalse( "Non-atomic condition expected", condition.isAtomic() );
+    assertEquals( 3, condition.nrConditions() );
+
+    Condition leftOr = condition.getCondition( 0 );
+
+    assertTrue( leftOr.isAtomic() );
+    assertEquals( "A", leftOr.getLeftValuename() );
+    assertEquals( "=", leftOr.getFunctionDesc() );
+    assertEquals( "Foo", leftOr.getRightExactString() );
+
+    Condition middleOr = condition.getCondition( 1 );
+    assertEquals( 2, middleOr.nrConditions() );
+
+    Condition leftAnd = middleOr.getCondition( 0 );
+    assertTrue( leftAnd.isAtomic() );
+    assertEquals( "B", leftAnd.getLeftValuename() );
+    assertEquals( ">", leftAnd.getFunctionDesc() );
+    assertEquals( "5", leftAnd.getRightExactString() );
+    assertEquals( Condition.OPERATOR_NONE, leftAnd.getOperator() );
+
+    Condition rightAnd = middleOr.getCondition( 1 );
+    assertEquals( Condition.OPERATOR_AND, rightAnd.getOperator() );
+    assertEquals( "C", rightAnd.getLeftValuename() );
+    assertEquals( "=", rightAnd.getFunctionDesc() );
+    assertEquals( "foo", rightAnd.getRightExactString() );
+
+    Condition rightOr = condition.getCondition( 2 );
+    assertTrue( rightOr.isAtomic() );
+    assertEquals( "D", rightOr.getLeftValuename() );
+    assertEquals( "=", rightOr.getFunctionDesc() );
+    assertEquals( "123", rightOr.getRightExactString() );
+    assertEquals( Condition.OPERATOR_OR, rightOr.getOperator() );
+  }
+
+  public void testCondition19() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "A LIKE '%AL%' AND ( B LIKE '15%' OR C IS NULL )";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertFalse( "Non-atomic condition expected", condition.isAtomic() );
+    assertEquals( 2, condition.nrConditions() );
+
+    Condition leftAnd = condition.getCondition( 0 );
+
+    assertTrue( leftAnd.isAtomic() );
+    assertEquals( "A", leftAnd.getLeftValuename() );
+    assertEquals( "LIKE", leftAnd.getFunctionDesc() );
+    assertEquals( "%AL%", leftAnd.getRightExactString() );
+
+    Condition rightBracket = condition.getCondition( 1 );
+    assertEquals( 1, rightBracket.nrConditions() );
+    Condition rightAnd = rightBracket.getCondition( 0 );
+    assertEquals( 2, rightAnd.nrConditions() );
+
+    Condition leftOr = rightAnd.getCondition( 0 );
+    assertTrue( leftOr.isAtomic() );
+    assertEquals( "B", leftOr.getLeftValuename() );
+    assertEquals( "LIKE", leftOr.getFunctionDesc() );
+    assertEquals( "15%", leftOr.getRightExactString() );
+    assertEquals( Condition.OPERATOR_NONE, leftOr.getOperator() );
+
+    Condition rightOr = rightAnd.getCondition( 1 );
+    assertEquals( Condition.OPERATOR_OR, rightOr.getOperator() );
+    assertEquals( "C", rightOr.getLeftValuename() );
+    assertEquals( "IS NULL", rightOr.getFunctionDesc() );
+    assertNull( rightOr.getRightExactString() );
+
+  }
+
+  public void testCondition20() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "NOT ( A = 'FOO' )";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertTrue( condition.isNegated() );
+    assertEquals( "A", condition.getLeftValuename() );
+    assertEquals( "=", condition.getFunctionDesc() );
+    assertEquals( "FOO", condition.getRightExactString() );
+  }
+
+  public void testCondition21() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "A='Foo' AND NOT ( B>5 )";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertFalse( "Non-atomic condition expected", condition.isAtomic() );
+    assertEquals( 2, condition.nrConditions() );
+
+    Condition one = condition.getCondition( 0 );
+    assertEquals( "A", one.getLeftValuename() );
+    assertEquals( "=", one.getFunctionDesc() );
+    assertEquals( "Foo", one.getRightExactString() );
+
+    Condition two = condition.getCondition( 1 );
+    assertTrue( two.isNegated() );
+    assertEquals( "B", two.getLeftValuename() );
+    assertEquals( ">", two.getFunctionDesc() );
+    assertEquals( "5", two.getRightExactString() );
+
+    assertEquals( Condition.OPERATOR_AND, two.getOperator() );
+  }
+
+  public void testCondition22() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B, C";
+    String conditionClause = "A='Foo' AND NOT ( B>5 OR C='AAA' ) ";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertFalse( "Non-atomic condition expected", condition.isAtomic() );
+    assertEquals( 2, condition.nrConditions() );
+
+    Condition leftAnd = condition.getCondition( 0 );
+    assertEquals( "A", leftAnd.getLeftValuename() );
+    assertEquals( "=", leftAnd.getFunctionDesc() );
+    assertEquals( "Foo", leftAnd.getRightExactString() );
+
+    Condition rightAnd = condition.getCondition( 1 );
+    assertEquals( 1, rightAnd.nrConditions() );
+
+    Condition notBlock = rightAnd.getCondition( 0 );
+    assertTrue( notBlock.isNegated() );
+    assertEquals( 2, notBlock.nrConditions() );
+
+    Condition leftOr = notBlock.getCondition( 0 );
+    assertTrue( leftOr.isAtomic() );
+    assertEquals( "B", leftOr.getLeftValuename() );
+    assertEquals( ">", leftOr.getFunctionDesc() );
+    assertEquals( "5", leftOr.getRightExactString() );
+    assertEquals( Condition.OPERATOR_NONE, leftOr.getOperator() );
+
+    Condition rightOr = notBlock.getCondition( 1 );
+    assertEquals( Condition.OPERATOR_OR, rightOr.getOperator() );
+    assertEquals( "C", rightOr.getLeftValuename() );
+    assertEquals( "=", rightOr.getFunctionDesc() );
+    assertEquals( "AAA", rightOr.getRightExactString() );
+  }
+
+  // Brackets, quotes...
+  //
+  public void testCondition23() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "( A LIKE '(AND' ) AND ( B>5 )";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertFalse( "Non-atomic condition expected", condition.isAtomic() );
+    assertEquals( 2, condition.nrConditions() );
+
+    Condition one = condition.getCondition( 0 );
+    assertEquals( "A", one.getLeftValuename() );
+    assertEquals( "LIKE", one.getFunctionDesc() );
+    assertEquals( "(AND", one.getRightExactString() );
+
+    Condition two = condition.getCondition( 1 );
+    assertEquals( "B", two.getLeftValuename() );
+    assertEquals( ">", two.getFunctionDesc() );
+    assertEquals( "5", two.getRightExactString() );
+
+    assertEquals( Condition.OPERATOR_AND, two.getOperator() );
+  }
+
+  // Brackets, quotes...
+  //
+  public void testCondition24() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "( A LIKE '(AND' ) AND ( ( B>5 ) OR ( B=3 ) )";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertFalse( "Non-atomic condition expected", condition.isAtomic() );
+    assertEquals( 2, condition.nrConditions() );
+
+    Condition one = condition.getCondition( 0 );
+    assertEquals( "A", one.getLeftValuename() );
+    assertEquals( "LIKE", one.getFunctionDesc() );
+    assertEquals( "(AND", one.getRightExactString() );
+
+    Condition two = condition.getCondition( 1 );
+    assertEquals( 1, two.nrConditions() );
+
+    Condition brackets = condition.getCondition( 1 );
+    assertEquals( 1, brackets.nrConditions() );
+
+    Condition right = brackets.getCondition( 0 );
+    assertEquals( 2, right.nrConditions() );
+
+    Condition leftOr = right.getCondition( 0 );
+    assertTrue( leftOr.isAtomic() );
+    assertEquals( "B", leftOr.getLeftValuename() );
+    assertEquals( ">", leftOr.getFunctionDesc() );
+    assertEquals( "5", leftOr.getRightExactString() );
+    assertEquals( Condition.OPERATOR_NONE, leftOr.getOperator() );
+
+    Condition rightOr = right.getCondition( 1 );
+    assertEquals( Condition.OPERATOR_OR, rightOr.getOperator() );
+    assertEquals( "B", rightOr.getLeftValuename() );
+    assertEquals( "=", rightOr.getFunctionDesc() );
+    assertEquals( "3", rightOr.getRightExactString() );
+
+  }
+
+  // Parameters...
+  //
+
+  public void testCondition25() throws KettleSQLException {
+    runParamTest( "PARAMETER('param')='FOO'",
+        "param",
+        "FOO" );
+  }
+
+  public void testLowerCaseParamInConditionClause() throws KettleSQLException {
+    runParamTest( "parameter('param')='FOO'",
+        "param",
+        "FOO" );
+  }
+
+  public void testMixedCaseParamInConditionClause() throws KettleSQLException {
+    runParamTest( "Parameter('param')='FOO'",
+        "param",
+        "FOO" );
+  }
+
+  public void testSpaceInParamNameAndValueInConditionClause() throws KettleSQLException {
+    runParamTest( "Parameter('My Parameter')='Foo Bar Baz'",
+        "My Parameter",
+        "Foo Bar Baz" );
+  }
+
+  public void testUnquotedNumericParameterValueInConditionClause() throws KettleSQLException {
+    runParamTest( "Parameter('My Parameter') = 123",
+        "My Parameter",
+        "123" );
+  }
+
+  public void testExtraneousWhitespaceInParameterConditionClause() throws KettleSQLException {
+    runParamTest( "Parameter   ( \t     'My Parameter'  \t   )  \t= \t    'My value'",
+        "My Parameter",
+        "My value" );
+  }
+
+  public void testParameterNameMissingThrows() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+    SQLFields fields = new SQLFields( "Service", rowMeta, "A, B" );
+    try {
+      new SQLCondition( "Service", "Parameter('') =  'My value'", rowMeta, fields );
+      fail();
+    } catch ( KettleSQLException kse ) {
+      assertTrue( kse.getMessage().contains( "A parameter name cannot be empty" ) );
+    }
+  }
+
+  public void testParameterValueMissingThrows() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+    SQLFields fields = new SQLFields( "Service", rowMeta, "A, B" );
+    try {
+      new SQLCondition( "Service", "Parameter('Foo') =  ''", rowMeta, fields );
+      fail();
+    } catch ( KettleSQLException kse ) {
+      assertTrue( kse.getMessage().contains( "A parameter value cannot be empty" ) );
+    }
+  }
+
+  private void runParamTest( String conditionClause, String paramName, String paramValue )
+      throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+    SQLFields fields = new SQLFields( "Service", rowMeta, "A, B" );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals(
+        String.format(
+            "Expected condition to be of type FUNC_TRUE, was (%s)",
+            Condition.functions[condition.getFunction()] ),
+        Condition.FUNC_TRUE, condition.getFunction() );
+
+    assertEquals( paramName, condition.getLeftValuename() );
+    assertEquals( paramValue, condition.getRightExactString() );
+  }
+
+  public void testCondition26() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest4RowMeta();
+
+    String fieldsClause = "A, B";
+    String conditionClause = "A='Foo' AND B>5 OR PARAMETER('par')='foo'";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertFalse( "Non-atomic condition expected", condition.isAtomic() );
+    assertEquals( 2, condition.nrConditions() );
+
+    Condition one = condition.getCondition( 0 );
+    assertEquals( 2, one.nrConditions() );
+
+    Condition leftAnd = one.getCondition( 0 );
+    assertEquals( "A", leftAnd.getLeftValuename() );
+    assertEquals( "=", leftAnd.getFunctionDesc() );
+    assertEquals( "Foo", leftAnd.getRightExactString() );
+    Condition rightAnd = one.getCondition( 1 );
+    assertEquals( "B", rightAnd.getLeftValuename() );
+    assertEquals( ">", rightAnd.getFunctionDesc() );
+    assertEquals( "5", rightAnd.getRightExactString() );
+    assertEquals( Condition.OPERATOR_AND, rightAnd.getOperator() );
+
+    Condition param = condition.getCondition( 1 );
+    assertTrue( param.isAtomic() );
+    assertEquals( Condition.OPERATOR_OR, param.getOperator() );
+    assertEquals( Condition.FUNC_TRUE, param.getFunction() );
+    assertEquals( "par", param.getLeftValuename() );
+    assertEquals( "foo", param.getRightExactString() );
+  }
+
+  public void testCondition27() throws Exception {
+
+    RowMetaInterface rowMeta = SQLTest.generateServiceRowMeta();
+    String fieldsClause = "\"Service\".\"Category\" as \"c0\", \"Service\".\"Country\" as \"c1\"";
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    String
+        conditionClause =
+        "(NOT((sum(\"Service\".\"sales_amount\") is null)) OR NOT((sum(\"Service\".\"products_sold\") is null)) )";
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+    assertNotNull( condition );
+  }
+
+  public void testCondition28() throws Exception {
+
+    RowMetaInterface rowMeta = SQLTest.generateServiceRowMeta();
+    String
+        fieldsClause =
+        "\"Service\".\"Category\" as \"c0\", \"Service\".\"Country\" as \"c1\" from \"Service\" as \"Service\"";
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    String conditionClause = "((not (\"Service\".\"Country\" = 'Belgium') or (\"Service\".\"Country\" is null)))";
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+    assertNotNull( condition );
+  }
+
+  public void testCondition29() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateGettingStartedRowMeta();
+
+    String fieldsClause = "CUSTOMERNAME";
+    String
+        conditionClause =
+        "\"GETTING_STARTED\".\"CUSTOMERNAME\" IN ('ANNA''S DECORATIONS, LTD', 'MEN ''R'' US RETAILERS, Ltd.' )";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( Condition.FUNC_IN_LIST, condition.getFunction() );
+
+    assertEquals( "\"GETTING_STARTED\".\"CUSTOMERNAME\"", condition.getLeftValuename() );
+    assertEquals( "ANNA'S DECORATIONS, LTD;MEN 'R' US RETAILERS, Ltd.", condition.getRightExactString() );
+  }
+
+  /**
+   * Test IN-clause with escaped quoting and semi-colons in them.
+   *
+   * @throws KettleSQLException
+   */
+  public void testCondition30() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateGettingStartedRowMeta();
+
+    String fieldsClause = "CUSTOMERNAME";
+    String conditionClause = "CUSTOMERNAME IN (''';''', 'Toys ''R'' us' )";
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( Condition.FUNC_IN_LIST, condition.getFunction() );
+
+    assertEquals( "CUSTOMERNAME", condition.getLeftValuename() );
+    assertEquals( "'\\;';Toys 'R' us", condition.getRightExactString() );
+  }
+
+  @Test
+  public void testLeftFieldWithTableQualifier() throws KettleSQLException {
+    RowMetaInterface rowMeta = mockRowMeta( "noSpaceField" );
+
+    SQLCondition sqlCondition = new SQLCondition(
+      "table", "\"table\".\"noSpaceField\" IS NULL", rowMeta );
+
+    Condition condition = sqlCondition.getCondition();
+    assertThat( condition.getFunctionDesc(), is( "IS NULL" ) );
+    assertThat( condition.getLeftValuename(), is( "noSpaceField" ) );
+    assertTrue( condition.isAtomic() );
+  }
+
+  @Test
+  public void testLeftFieldWithSpaceAndTableQualifier() throws KettleSQLException {
+    RowMetaInterface rowMeta = mockRowMeta( "Space Field" );
+
+    SQLCondition sqlCondition = new SQLCondition(
+      "table", "\"table\".\"Space Field\" IS NULL", rowMeta );
+    Condition condition = sqlCondition.getCondition();
+    assertThat( condition.getFunctionDesc(), is( "IS NULL" ) );
+    assertThat( condition.getLeftValuename(), is( "Space Field" ) );
+    assertTrue( condition.isAtomic() );
+  }
+
+  @Test
+  public void testLeftAndRightFieldWithSpaceAndTableQualifier() throws KettleSQLException {
+    RowMetaInterface rowMeta = mockRowMeta( "Left Field", "Right Field" );
+
+    SQLCondition sqlCondition = new SQLCondition(
+      "table", "\"table\".\"Left Field\" = \"table\".\"Right Field\"", rowMeta );
+    Condition condition = sqlCondition.getCondition();
+    assertThat( condition.getFunctionDesc(), is( "=" ) );
+    assertThat( condition.getLeftValuename(), is( "Left Field" ) );
+    assertThat( condition.getRightValuename(), is( "Right Field" ) );
+    assertTrue( condition.isAtomic() );
+  }
+
+  @Test
+  public void testCompoundConditionLeftFieldWithSpaceAndTableQualifier() throws KettleSQLException {
+    RowMetaInterface rowMeta = mockRowMeta( "Space Field" );
+
+    SQLCondition sqlCondition = new SQLCondition(
+      "table", "\"table\".\"Space Field\" IS NULL AND \"table\".\"Space Field\" > 1", rowMeta );
+    Condition condition = sqlCondition.getCondition();
+    assertThat( condition.getChildren().size(), is( 2 ) );
+
+    List<Condition> children = condition.getChildren();
+    assertThat( children.get( 0 ).getFunctionDesc(), is( "IS NULL" ) );
+    assertThat( children.get( 0 ).getLeftValuename(), is( "Space Field" ) );
+    assertThat( children.get( 1 ).getOperator(), is( Condition.OPERATOR_AND ) );
+    assertThat( children.get( 1 ).getFunctionDesc(), is( ">" ) );
+    assertThat( children.get( 1 ).getLeftValuename(), is( "Space Field" ) );
+    assertTrue( condition.isComposite() );
+  }
+}

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLFieldTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLFieldTest.java
@@ -1,0 +1,514 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.sql;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.pentaho.di.core.Condition;
+import org.pentaho.di.core.exception.KettleSQLException;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+import static org.pentaho.di.core.sql.SQLTest.mockRowMeta;
+
+public class SQLFieldTest extends TestCase {
+
+  public void testSqlField01() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "A as foo";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "A", field.getName() );
+    assertEquals( "foo", field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField01Alias() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "Service.A as foo";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "A", field.getName() );
+    assertEquals( "foo", field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField01QuotedAlias() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "\"Service\".A as foo";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "A", field.getName() );
+    assertEquals( "foo", field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField02() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "A as \"foo\"";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "A", field.getName() );
+    assertEquals( "foo", field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField02Alias() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "Service.A as \"foo\"";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "A", field.getName() );
+    assertEquals( "foo", field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField03() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "\"A\" as \"foo\"";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "A", field.getName() );
+    assertEquals( "foo", field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField03Alias() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "Service.\"A\" as \"foo\"";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "A", field.getName() );
+    assertEquals( "foo", field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField04() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "\"A\" \"foo\"";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "A", field.getName() );
+    assertEquals( "foo", field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField04Alias() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "Service.\"A\" \"foo\"";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "A", field.getName() );
+    assertEquals( "foo", field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField05() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "A   as   foo";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "A", field.getName() );
+    assertEquals( "foo", field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField05Alias() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "Service.A   as   foo";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "A", field.getName() );
+    assertEquals( "foo", field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField06() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "SUM(B) as total";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "B", field.getName() );
+    assertEquals( "total", field.getAlias() );
+    assertEquals( SQLAggregation.SUM, field.getAggregation() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField06Alias() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "SUM(Service.B) as total";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "B", field.getName() );
+    assertEquals( "total", field.getAlias() );
+    assertEquals( SQLAggregation.SUM, field.getAggregation() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField07() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "SUM( B ) as total";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "B", field.getName() );
+    assertEquals( "total", field.getAlias() );
+    assertEquals( SQLAggregation.SUM, field.getAggregation() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField07Alias() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "SUM( Service.B ) as total";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "B", field.getName() );
+    assertEquals( "total", field.getAlias() );
+    assertEquals( SQLAggregation.SUM, field.getAggregation() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField08() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "SUM( \"B\" ) as total";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "B", field.getName() );
+    assertEquals( "total", field.getAlias() );
+    assertEquals( SQLAggregation.SUM, field.getAggregation() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField08Alias() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "SUM( Service.\"B\" ) as total";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "B", field.getName() );
+    assertEquals( "total", field.getAlias() );
+    assertEquals( SQLAggregation.SUM, field.getAggregation() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField09() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "SUM(\"B\") as   \"total\"";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "B", field.getName() );
+    assertEquals( "total", field.getAlias() );
+    assertEquals( SQLAggregation.SUM, field.getAggregation() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField09Alias() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "SUM(Service.\"B\") as   \"total\"";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "B", field.getName() );
+    assertEquals( "total", field.getAlias() );
+    assertEquals( SQLAggregation.SUM, field.getAggregation() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+  }
+
+  public void testSqlField10() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "COUNT(*) as   \"Number of lines\"";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "*", field.getName() );
+    assertEquals( "Number of lines", field.getAlias() );
+    assertEquals( SQLAggregation.COUNT, field.getAggregation() );
+    assertNull( field.getValueMeta() );
+    assertTrue( field.isCountStar() );
+  }
+
+  public void testSqlField10NoAlias() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "COUNT(*)";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "*", field.getName() );
+    assertEquals( "COUNT(*)", field.getAlias() );
+    assertEquals( SQLAggregation.COUNT, field.getAggregation() );
+    assertNull( field.getValueMeta() );
+    assertTrue( field.isCountStar() );
+  }
+
+  public void testSqlField10Alias() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "COUNT(Service.*) as   \"Number of lines\"";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "*", field.getName() );
+    assertEquals( "Number of lines", field.getAlias() );
+    assertEquals( SQLAggregation.COUNT, field.getAggregation() );
+    assertNull( field.getValueMeta() );
+    assertTrue( field.isCountStar() );
+  }
+
+  public void testSqlField11() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "COUNT(DISTINCT A) as   \"Number of customers\"";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "A", field.getName() );
+    assertEquals( "Number of customers", field.getAlias() );
+    assertEquals( SQLAggregation.COUNT, field.getAggregation() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertTrue( field.isCountDistinct() );
+  }
+
+  public void testSqlField11Alias() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "COUNT(DISTINCT Service.A) as   \"Number of customers\"";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "A", field.getName() );
+    assertEquals( "Number of customers", field.getAlias() );
+    assertEquals( SQLAggregation.COUNT, field.getAggregation() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertTrue( field.isCountDistinct() );
+  }
+
+  public void testSqlField12_Function() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "IIF( B>5000, 'Big', 'Small' ) as \"Sales size\"";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "IIF( B>5000, 'Big', 'Small' )", field.getName() );
+    assertEquals( "Sales size", field.getAlias() );
+    assertNull( "The service data type was discovered", field.getValueMeta() );
+
+    assertNotNull( field.getIif() );
+    Condition condition = field.getIif().getSqlCondition().getCondition();
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "B", condition.getLeftValuename() );
+    assertEquals( ">", condition.getFunctionDesc() );
+    assertEquals( "5000", condition.getRightExactString() );
+  }
+
+  public void testSqlField12Alias_Function() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "IIF( Service.B>5000, 'Big', 'Small' ) as \"Sales size\"";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "IIF( Service.B>5000, 'Big', 'Small' )", field.getName() );
+    assertEquals( "Sales size", field.getAlias() );
+    assertNull( "The service data type was discovered", field.getValueMeta() );
+
+    assertNotNull( field.getIif() );
+    Condition condition = field.getIif().getSqlCondition().getCondition();
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "B", condition.getLeftValuename() );
+    assertEquals( ">", condition.getFunctionDesc() );
+    assertEquals( "5000", condition.getRightExactString() );
+  }
+
+  public void testSqlField13_Function() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "IIF( B>50, 'high', 'low' ) as nrSize";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "IIF( B>50, 'high', 'low' )", field.getName() );
+    assertEquals( "nrSize", field.getAlias() );
+    assertNull( "The service data type was discovered", field.getValueMeta() );
+
+    assertNotNull( field.getIif() );
+    Condition condition = field.getIif().getSqlCondition().getCondition();
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "B", condition.getLeftValuename() );
+    assertEquals( ">", condition.getFunctionDesc() );
+    assertEquals( "50", condition.getRightExactString() );
+  }
+
+  public void testSqlField13Alias_Function() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "IIF( Service.B>50, 'high', 'low' ) as nrSize";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "IIF( Service.B>50, 'high', 'low' )", field.getName() );
+    assertEquals( "nrSize", field.getAlias() );
+    assertNull( "The service data type was discovered", field.getValueMeta() );
+
+    assertNotNull( field.getIif() );
+    Condition condition = field.getIif().getSqlCondition().getCondition();
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( "B", condition.getLeftValuename() );
+    assertEquals( ">", condition.getFunctionDesc() );
+    assertEquals( "50", condition.getRightExactString() );
+  }
+
+  public void testSqlFieldConstants01() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "1";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "1", field.getName() );
+    assertNull( field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertEquals( field.getValueMeta().getType(), ValueMetaInterface.TYPE_INTEGER );
+    assertEquals( 1L, field.getValueData() );
+  }
+
+  public void testSqlFieldConstants02() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldClause = "COUNT(1)";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "1", field.getName() );
+    assertEquals( "COUNT(1)", field.getAlias() );
+    assertEquals( SQLAggregation.COUNT, field.getAggregation() );
+    assertEquals( 1L, field.getValueData() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertEquals( field.getValueMeta().getType(), ValueMetaInterface.TYPE_INTEGER );
+    assertEquals( 1L, field.getValueData() );
+  }
+
+  /**
+   * Mondrian generated CASE WHEN <condition> THEN true-value ELSE false-value END
+   *
+   * @throws KettleSQLException
+   */
+  public void testSqlFieldCaseWhen01() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateServiceRowMeta();
+
+    String fieldClause = "CASE WHEN \"Service\".\"Category\" IS NULL THEN 1 ELSE 0 END";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "CASE WHEN \"Service\".\"Category\" IS NULL THEN 1 ELSE 0 END", field.getName() );
+    assertNull( field.getAlias() );
+    assertNotNull( field.getIif() );
+    assertEquals( "\"Service\".\"Category\" IS NULL", field.getIif().getConditionClause() );
+    assertEquals( 1L, field.getIif().getTrueValue().getValueData() );
+    assertEquals( 0L, field.getIif().getFalseValue().getValueData() );
+  }
+
+  @Test
+  public void testAggFieldWithTableQualifier() throws KettleSQLException {
+    RowMetaInterface rowMeta = mockRowMeta( "noSpaceField" );
+    SQLField field = new SQLField( "noSpaceTableAlias", "sum(noSpaceField)",
+      rowMeta );
+    assertThat( field.getField(), is( "noSpaceField" ) );
+    assertThat( field.getAggregation().getKeyWord(), is( "SUM" ) );
+    verify( rowMeta, atLeastOnce() ).searchValueMeta( "noSpaceField" );
+  }
+
+  @Test
+  public void testAggFieldWithSpaceAndWithTableQualifier() throws KettleSQLException {
+    RowMetaInterface rowMeta = mockRowMeta( "Space Field", "otherField" );
+    SQLField field = new SQLField( "noSpaceTableAlias", "sum(\"noSpaceTableAlias\".\"Space Field\")",
+      rowMeta );
+    assertThat( field.getField(), is( "Space Field" ) );
+    assertThat( field.getAggregation().getKeyWord(), is( "SUM" ) );
+    verify( rowMeta, atLeastOnce() ).searchValueMeta( "Space Field" );
+  }
+
+  @Test
+  public void testAggFieldWithSpaceAndWithTableQualifierAndAlias() throws KettleSQLException {
+    RowMetaInterface rowMeta = mockRowMeta( "Space Field" );
+    SQLField field = new SQLField(
+      "noSpaceTableAlias", "max( \"noSpaceTableAlias\".\"Space Field\")  as \"c0\"",
+      rowMeta );
+    assertThat( field.getField(), is( "Space Field" ) );
+    assertThat( field.getAggregation().getKeyWord(), is( "MAX" ) );
+    verify( rowMeta, atLeastOnce() ).searchValueMeta( "Space Field" );
+  }
+
+  @Test
+  public void testAggFieldDistinctWithNoSpace() throws KettleSQLException {
+    RowMetaInterface rowMeta = mockRowMeta( "NoSpaceField" );
+    SQLField field = new SQLField(
+      "noSpaceTableAlias", "count( DISTINCT NoSpaceField) ",
+      rowMeta );
+    assertThat( field.getField(), is( "NoSpaceField" ) );
+    assertThat( field.getAggregation().getKeyWord(), is( "COUNT" ) );
+    assertThat( field.isCountDistinct(), is( true ) );
+    verify( rowMeta, atLeastOnce() ).searchValueMeta( "NoSpaceField" );
+  }
+
+  @Test
+  public void testAggFieldDistinctWithSpace() throws KettleSQLException {
+    RowMetaInterface rowMeta = mockRowMeta( "Space Field" );
+    SQLField field = new SQLField(
+      "noSpaceTableAlias", "count( DISTINCT \"Space Field\") ",
+      rowMeta );
+    assertThat( field.getField(), is( "Space Field" ) );
+    assertThat( field.getAggregation().getKeyWord(), is( "COUNT" ) );
+    assertThat( field.isCountDistinct(), is( true ) );
+    verify( rowMeta, atLeastOnce() ).searchValueMeta( "Space Field" );
+  }
+
+  @Test
+  public void testAggFieldDistinctWithSpaceAndWithTableQualifierAndAlias() throws KettleSQLException {
+    RowMetaInterface rowMeta = mockRowMeta( "Space Field" );
+    SQLField field = new SQLField(
+      "Space TableAlias", "count( DISTINCT \"Space TableAlias\".\"Space Field\")  as \"c0\"",
+      rowMeta );
+    assertThat( field.getField(), is( "Space Field" ) );
+    assertThat( field.getAggregation().getKeyWord(), is( "COUNT" ) );
+    assertThat( field.isCountDistinct(), is( true ) );
+    verify( rowMeta, atLeastOnce() ).searchValueMeta( "Space Field" );
+  }
+}

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLFieldsTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLFieldsTest.java
@@ -1,0 +1,204 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.sql;
+
+import junit.framework.TestCase;
+
+import org.pentaho.di.core.exception.KettleSQLException;
+import org.pentaho.di.core.row.RowMetaInterface;
+
+public class SQLFieldsTest extends TestCase {
+
+  public void testSqlFromFields01() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldsClause = "A, B";
+
+    SQLFields fromFields = new SQLFields( "Service", rowMeta, fieldsClause );
+    assertFalse( fromFields.isDistinct() );
+
+    assertEquals( 2, fromFields.getFields().size() );
+
+    SQLField field = fromFields.getFields().get( 0 );
+    assertEquals( "A", field.getName() );
+    assertNull( field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertEquals( "A", field.getValueMeta().getName().toUpperCase() );
+
+    field = fromFields.getFields().get( 1 );
+    assertEquals( "B", field.getName() );
+    assertNull( field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertEquals( "B", field.getValueMeta().getName().toUpperCase() );
+  }
+
+  public void testSqlFromFields02() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldsClause = "A as foo, B";
+
+    SQLFields fromFields = new SQLFields( "Service", rowMeta, fieldsClause );
+    assertFalse( fromFields.isDistinct() );
+
+    assertEquals( 2, fromFields.getFields().size() );
+
+    SQLField field = fromFields.getFields().get( 0 );
+    assertEquals( "A", field.getName() );
+    assertEquals( "foo", field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertEquals( "A", field.getValueMeta().getName().toUpperCase() );
+
+    field = fromFields.getFields().get( 1 );
+    assertEquals( "B", field.getName() );
+    assertNull( field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertEquals( "B", field.getValueMeta().getName().toUpperCase() );
+  }
+
+  public void testSqlFromFields03() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldsClause = "A, sum( B ) as \"Total sales\"";
+
+    SQLFields fromFields = new SQLFields( "Service", rowMeta, fieldsClause );
+    assertFalse( fromFields.isDistinct() );
+
+    assertEquals( 2, fromFields.getFields().size() );
+
+    SQLField field = fromFields.getFields().get( 0 );
+    assertEquals( "A", field.getName() );
+    assertNull( field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertEquals( "A", field.getValueMeta().getName().toUpperCase() );
+
+    field = fromFields.getFields().get( 1 );
+    assertEquals( "B", field.getName() );
+    assertEquals( "Total sales", field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertEquals( "B", field.getValueMeta().getName().toUpperCase() );
+  }
+
+  public void testSqlFromFields04() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldsClause = "DISTINCT A as foo, B as bar";
+
+    SQLFields fromFields = new SQLFields( "Service", rowMeta, fieldsClause );
+    assertTrue( fromFields.isDistinct() );
+
+    assertEquals( 2, fromFields.getFields().size() );
+
+    SQLField field = fromFields.getFields().get( 0 );
+    assertEquals( "A", field.getName() );
+    assertEquals( "foo", field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertEquals( "A", field.getValueMeta().getName().toUpperCase() );
+
+    field = fromFields.getFields().get( 1 );
+    assertEquals( "B", field.getName() );
+    assertEquals( "bar", field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertEquals( "B", field.getValueMeta().getName().toUpperCase() );
+  }
+
+  public void testSqlFromFields05() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldsClause = "*";
+
+    SQLFields fromFields = new SQLFields( "Service", rowMeta, fieldsClause );
+    assertFalse( fromFields.isDistinct() );
+
+    assertEquals( 2, fromFields.getFields().size() );
+
+    SQLField field = fromFields.getFields().get( 0 );
+    assertEquals( "A", field.getName() );
+    assertNull( field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertEquals( "A", field.getValueMeta().getName().toUpperCase() );
+
+    field = fromFields.getFields().get( 1 );
+    assertEquals( "B", field.getName() );
+    assertNull( field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertEquals( "B", field.getValueMeta().getName().toUpperCase() );
+  }
+
+  public void testSqlFromFields05Alias() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldsClause = "Service.*";
+
+    SQLFields fromFields = new SQLFields( "Service", rowMeta, fieldsClause );
+    assertFalse( fromFields.isDistinct() );
+
+    assertEquals( 2, fromFields.getFields().size() );
+
+    SQLField field = fromFields.getFields().get( 0 );
+    assertEquals( "A", field.getName() );
+    assertNull( field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertEquals( "A", field.getValueMeta().getName().toUpperCase() );
+
+    field = fromFields.getFields().get( 1 );
+    assertEquals( "B", field.getName() );
+    assertNull( field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertEquals( "B", field.getValueMeta().getName().toUpperCase() );
+  }
+
+  public void testSqlFromFields06() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMeta();
+
+    String fieldsClause = "*, *";
+
+    SQLFields fromFields = new SQLFields( "Service", rowMeta, fieldsClause );
+    assertFalse( fromFields.isDistinct() );
+
+    assertEquals( 4, fromFields.getFields().size() );
+
+    SQLField field = fromFields.getFields().get( 0 );
+    assertEquals( "A", field.getName() );
+    assertNull( field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertEquals( "A", field.getValueMeta().getName().toUpperCase() );
+
+    field = fromFields.getFields().get( 1 );
+    assertEquals( "B", field.getName() );
+    assertNull( field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertEquals( "B", field.getValueMeta().getName().toUpperCase() );
+
+    field = fromFields.getFields().get( 2 );
+    assertEquals( "A", field.getName() );
+    assertNull( field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertEquals( "A", field.getValueMeta().getName().toUpperCase() );
+
+    field = fromFields.getFields().get( 3 );
+    assertEquals( "B", field.getName() );
+    assertNull( field.getAlias() );
+    assertNotNull( "The service data type was not discovered", field.getValueMeta() );
+    assertEquals( "B", field.getValueMeta().getName().toUpperCase() );
+  }
+}

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLFieldsUnitTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLFieldsUnitTest.java
@@ -1,0 +1,131 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.sql;
+
+import com.google.common.collect.ImmutableList;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.di.core.exception.KettleSQLException;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMetaInterface;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.mockito.Mockito;
+
+@SuppressWarnings( "unchecked" )
+public class SQLFieldsUnitTest {
+  private static final String NO_SPACE = "nospace";
+  private static final String WITH_SPACES = "with spaces";
+  private static final String SELECT_CLAUSE = String.format( "%s, \"%s\"", NO_SPACE, WITH_SPACES );
+  private static final String TABLE = "table";
+  private static final String SELECT_CLAUSE_TABLE_QUALIFIER = String.format(
+    "%s.%s, \"%s\".\"%s\"", TABLE, NO_SPACE, TABLE, WITH_SPACES );
+
+  private RowMetaInterface serviceFields;
+
+  @Before
+  public void setup() {
+    serviceFields = Mockito.mock( RowMetaInterface.class );
+
+    String nospace = NO_SPACE;
+    String withSpaces = WITH_SPACES;
+    ValueMetaInterface nospaceVmi = Mockito.mock( ValueMetaInterface.class );
+    ValueMetaInterface spaceVmi = Mockito.mock( ValueMetaInterface.class );
+
+    List<ValueMetaInterface> valueMetaList = Arrays.asList( nospaceVmi, spaceVmi );
+    Mockito.when( serviceFields.getValueMetaList() ).thenReturn( valueMetaList );
+    Mockito.when( nospaceVmi.getName() ).thenReturn( nospace );
+    Mockito.when( spaceVmi.getName() ).thenReturn( withSpaces );
+    Mockito.when( serviceFields.searchValueMeta( nospace ) ).thenReturn( nospaceVmi );
+    Mockito.when( serviceFields.searchValueMeta( withSpaces ) ).thenReturn( spaceVmi );
+  }
+
+  @Test
+  public void testParseFields() throws KettleSQLException {
+    SQLFields sqlFields = new SQLFields( TABLE, serviceFields, SELECT_CLAUSE );
+    checkSqlFields( sqlFields, SELECT_CLAUSE );
+  }
+
+  @Test
+  public void testParseFieldsWithTableQualifier() throws KettleSQLException {
+    SQLFields sqlFields = new SQLFields( TABLE, serviceFields, SELECT_CLAUSE_TABLE_QUALIFIER );
+    // same test as the preceding but with fields referenced like "table"."with space".
+    checkSqlFields( sqlFields, SELECT_CLAUSE_TABLE_QUALIFIER );
+  }
+
+  private void checkSqlFields( SQLFields sqlFields, String selectClause ) {
+    Assert.assertThat( sqlFields.getTableAlias(), CoreMatchers.sameInstance( TABLE ) );
+    Assert.assertThat( sqlFields.getServiceFields(), CoreMatchers.sameInstance( serviceFields ) );
+    Assert.assertThat( sqlFields.getFieldsClause(), CoreMatchers.equalTo( selectClause ) );
+
+    Assert.assertThat( sqlFields.getFields(), validSqlFields() );
+    Assert.assertThat( sqlFields.findByName( NO_SPACE ), sqlField( NO_SPACE ) );
+
+    Assert.assertThat( sqlFields.getNonAggregateFields(), validSqlFields() );
+    Assert.assertThat( sqlFields.getRegularFields(), validSqlFields() );
+
+    Assert.assertThat( sqlFields.getAggregateFields(), Matchers.empty() );
+    Assert.assertThat( sqlFields.hasAggregates(), Matchers.is( false ) );
+
+    Assert.assertThat( sqlFields.getConstantFields(), Matchers.empty() );
+    Assert.assertThat( sqlFields.getIifFunctionFields(), Matchers.empty() );
+  }
+
+  @Test
+  public void testParseStar() throws KettleSQLException {
+    SQLFields sqlFields = new SQLFields( TABLE, serviceFields, "*" );
+
+    Assert.assertThat( sqlFields.getFields(), validSqlFields() );
+  }
+
+  @Test
+  public void testDistinct() throws Exception {
+    for ( SQLFields sqlFields : ImmutableList.of(
+      new SQLFields( TABLE, serviceFields, "distinct " + SELECT_CLAUSE ),
+      new SQLFields( TABLE, serviceFields, "Distinct " + SELECT_CLAUSE ),
+      new SQLFields( TABLE, serviceFields, "DISTINCT " + SELECT_CLAUSE )
+    ) ) {
+      Assert.assertThat( sqlFields.getFieldsClause(), CoreMatchers.equalTo( SELECT_CLAUSE ) );
+      Assert.assertThat( sqlFields.getFields(), validSqlFields() );
+      Assert.assertThat( sqlFields.isDistinct(), Matchers.is( true ) );
+    }
+  }
+
+
+  public Matcher<Iterable<? extends SQLField>> validSqlFields() {
+    return Matchers.contains( sqlField( NO_SPACE ), sqlField( WITH_SPACES ) );
+  }
+
+  public Matcher<? super SQLField> sqlField( String name ) {
+    return CoreMatchers.allOf(
+      Matchers.instanceOf( SQLField.class ),
+      Matchers.hasProperty( "name", CoreMatchers.equalTo( name ) )
+    );
+  }
+}

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLTest.java
@@ -1,0 +1,552 @@
+/*! ******************************************************************************
+ *
+ * Pentaho Data Integration
+ *
+ * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ *
+ *******************************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+package org.pentaho.di.core.sql;
+
+import java.util.List;
+
+import org.pentaho.di.core.exception.KettleSQLException;
+import org.pentaho.di.core.jdbc.ThinUtil;
+import org.pentaho.di.core.row.RowMeta;
+import org.pentaho.di.core.row.RowMetaInterface;
+import org.pentaho.di.core.row.ValueMeta;
+import org.pentaho.di.core.row.ValueMetaInterface;
+
+import junit.framework.TestCase;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SQLTest extends TestCase {
+
+  public void testSql01() throws KettleSQLException {
+    RowMetaInterface rowMeta = generateTest3RowMeta();
+
+    String sqlString = "SELECT A, B, C\nFROM Service\nWHERE B > 5\nORDER BY B DESC";
+
+    SQL sql = new SQL( sqlString );
+
+    assertEquals( "Service", sql.getServiceName() );
+    sql.parse( rowMeta );
+
+    assertEquals( "A, B, C", sql.getSelectClause() );
+    List<SQLField> selectFields = sql.getSelectFields().getFields();
+    assertEquals( 3, selectFields.size() );
+
+    assertEquals( "B > 5", sql.getWhereClause() );
+    SQLCondition whereCondition = sql.getWhereCondition();
+    assertNotNull( whereCondition.getCondition() );
+
+    assertNull( sql.getGroupClause() );
+    assertNull( sql.getHavingClause() );
+    assertEquals( "B DESC", sql.getOrderClause() );
+    List<SQLField> orderFields = sql.getOrderFields().getFields();
+    assertEquals( 1, orderFields.size() );
+    SQLField orderField = orderFields.get( 0 );
+    assertTrue( orderField.isOrderField() );
+    assertFalse( orderField.isAscending() );
+    assertNull( orderField.getAlias() );
+    assertEquals( "B", orderField.getValueMeta().getName().toUpperCase() );
+  }
+
+  public void testSql02() throws KettleSQLException {
+    RowMetaInterface rowMeta = generateTest3RowMeta();
+
+    String sqlString = "SELECT A as \"FROM\", B as \"TO\", C\nFROM Service\nWHERE B > 5\nORDER BY B DESC";
+
+    SQL sql = new SQL( sqlString );
+
+    assertEquals( "Service", sql.getServiceName() );
+    sql.parse( rowMeta );
+
+    assertEquals( "A as \"FROM\", B as \"TO\", C", sql.getSelectClause() );
+    assertEquals( "B > 5", sql.getWhereClause() );
+    assertNull( sql.getGroupClause() );
+    assertNull( sql.getHavingClause() );
+    assertEquals( "B DESC", sql.getOrderClause() );
+  }
+
+  public void testSql03() throws KettleSQLException {
+    RowMetaInterface rowMeta = generateTest3RowMeta();
+
+    String sqlString =
+      "SELECT A as \"FROM\", B as \"TO\", C, COUNT(*)\nFROM Service\nWHERE B > 5\nGROUP BY A,B,C\nHAVING COUNT(*) > 100\nORDER BY A,B,C";
+
+    SQL sql = new SQL( sqlString );
+
+    assertEquals( "Service", sql.getServiceName() );
+    sql.parse( rowMeta );
+
+    assertEquals( "A as \"FROM\", B as \"TO\", C, COUNT(*)", sql.getSelectClause() );
+    assertEquals( "B > 5", sql.getWhereClause() );
+    assertEquals( "A,B,C", sql.getGroupClause() );
+    assertEquals( "COUNT(*) > 100", sql.getHavingClause() );
+    assertEquals( "A,B,C", sql.getOrderClause() );
+  }
+
+  public void testSql04() throws KettleSQLException {
+    RowMetaInterface rowMeta = generateTest3RowMeta();
+
+    String sqlString = "SELECT *\nFROM Service\nWHERE B > 5\nORDER BY B DESC";
+
+    SQL sql = new SQL( sqlString );
+
+    assertEquals( "Service", sql.getServiceName() );
+    sql.parse( rowMeta );
+
+    assertEquals( "*", sql.getSelectClause() );
+    List<SQLField> selectFields = sql.getSelectFields().getFields();
+    assertEquals( 3, selectFields.size() );
+
+    assertEquals( "B > 5", sql.getWhereClause() );
+    SQLCondition whereCondition = sql.getWhereCondition();
+    assertNotNull( whereCondition.getCondition() );
+
+    assertNull( sql.getGroupClause() );
+    assertNull( sql.getHavingClause() );
+    assertEquals( "B DESC", sql.getOrderClause() );
+    List<SQLField> orderFields = sql.getOrderFields().getFields();
+    assertEquals( 1, orderFields.size() );
+    SQLField orderField = orderFields.get( 0 );
+    assertTrue( orderField.isOrderField() );
+    assertFalse( orderField.isAscending() );
+    assertNull( orderField.getAlias() );
+    assertEquals( "B", orderField.getValueMeta().getName().toUpperCase() );
+  }
+
+  public void testSql05() throws KettleSQLException {
+    RowMetaInterface rowMeta = generateTest3RowMeta();
+
+    String sqlString = "SELECT count(*) as NrOfRows FROM Service";
+
+    SQL sql = new SQL( sqlString );
+
+    assertEquals( "Service", sql.getServiceName() );
+    sql.parse( rowMeta );
+
+    assertEquals( "count(*) as NrOfRows", sql.getSelectClause() );
+    List<SQLField> selectFields = sql.getSelectFields().getFields();
+    assertEquals( 1, selectFields.size() );
+    SQLField countField = selectFields.get( 0 );
+    assertTrue( countField.isCountStar() );
+    assertEquals( "*", countField.getField() );
+    assertEquals( "NrOfRows", countField.getAlias() );
+
+    assertNull( sql.getGroupClause() );
+    assertNotNull( sql.getGroupFields() );
+    assertNull( sql.getHavingClause() );
+    assertNull( sql.getOrderClause() );
+  }
+
+  /**
+   * Query generated by interactive reporting.
+   *
+   * @throws KettleSQLException
+   */
+  public void testSql06() throws KettleSQLException {
+    RowMetaInterface rowMeta = generateServiceRowMeta();
+
+    String sqlString =
+      "SELECT DISTINCT\n          BT_SERVICE_SERVICE.Category AS COL0\n         ,BT_SERVICE_SERVICE.Country AS COL1\n         ,BT_SERVICE_SERVICE.products_sold AS COL2\n         ,BT_SERVICE_SERVICE.sales_amount AS COL3\n"
+        + "FROM \n          Service BT_SERVICE_SERVICE\n" + "ORDER BY\n          COL0";
+
+    SQL sql = new SQL( ThinUtil.stripNewlines( sqlString ) );
+
+    assertEquals( "Service", sql.getServiceName() );
+    sql.parse( rowMeta );
+
+    assertTrue( sql.getSelectFields().isDistinct() );
+    List<SQLField> selectFields = sql.getSelectFields().getFields();
+    assertEquals( 4, selectFields.size() );
+    assertEquals( "COL0", selectFields.get( 0 ).getAlias() );
+    assertEquals( "COL1", selectFields.get( 1 ).getAlias() );
+    assertEquals( "COL2", selectFields.get( 2 ).getAlias() );
+    assertEquals( "COL3", selectFields.get( 3 ).getAlias() );
+
+    List<SQLField> orderFields = sql.getOrderFields().getFields();
+    assertEquals( 1, orderFields.size() );
+  }
+
+  /**
+   * Query generated by Mondrian / Analyzer.
+   *
+   * @throws KettleSQLException
+   */
+  public void testSql07() throws KettleSQLException {
+    RowMetaInterface rowMeta = generateServiceRowMeta();
+
+    String sqlString =
+      "select \"Service\".\"Category\" as \"c0\" from \"Service\" as \"Service\" group by \"Service\".\"Category\" order by CASE WHEN \"Service\".\"Category\" IS NULL THEN 1 ELSE 0 END, \"Service\".\"Category\" ASC";
+
+    SQL sql = new SQL( ThinUtil.stripNewlines( sqlString ) );
+
+    assertEquals( "Service", sql.getServiceName() );
+    sql.parse( rowMeta );
+
+    assertFalse( sql.getSelectFields().isDistinct() );
+    List<SQLField> selectFields = sql.getSelectFields().getFields();
+    assertEquals( 1, selectFields.size() );
+    assertEquals( "c0", selectFields.get( 0 ).getAlias() );
+
+    List<SQLField> orderFields = sql.getOrderFields().getFields();
+    assertEquals( 2, orderFields.size() );
+  }
+
+  //
+  /**
+   * Query generated by PIR
+   *
+   * @throws KettleSQLException
+   */
+  public void testSql08() throws KettleSQLException {
+    RowMetaInterface rowMeta = generateZipsRowMeta();
+
+    String sqlString =
+      "SELECT            BT_MONGODB_MONGODB.state AS COL0          ,SUM(BT_MONGODB_MONGODB.rows) AS COL1 FROM            MongoDB BT_MONGODB_MONGODB GROUP BY            BT_MONGODB_MONGODB.state ORDER BY            COL1 DESC";
+
+    SQL sql = new SQL( ThinUtil.stripNewlines( sqlString ) );
+
+    assertEquals( "MongoDB", sql.getServiceName() );
+    sql.parse( rowMeta );
+
+    assertFalse( sql.getSelectFields().isDistinct() );
+    List<SQLField> selectFields = sql.getSelectFields().getFields();
+    assertEquals( 2, selectFields.size() );
+    assertEquals( "state", selectFields.get( 0 ).getField() );
+    assertEquals( "COL0", selectFields.get( 0 ).getAlias() );
+    assertEquals( "rows", selectFields.get( 1 ).getField() );
+    assertEquals( "COL1", selectFields.get( 1 ).getAlias() );
+
+    List<SQLField> orderFields = sql.getOrderFields().getFields();
+    assertEquals( 1, orderFields.size() );
+  }
+
+  /**
+   * Tests schema.table format
+   *
+   * @throws KettleSQLException
+   */
+  public void testSql09() throws KettleSQLException {
+    RowMetaInterface rowMeta = generateServiceRowMeta();
+
+    String sqlString = "SELECT Category, Country, products_sold, sales_amount FROM Kettle.Service";
+
+    SQL sql = new SQL( ThinUtil.stripNewlines( sqlString ) );
+
+    assertEquals( "Kettle", sql.getNamespace() );
+    assertEquals( "Service", sql.getServiceName() );
+    sql.parse( rowMeta );
+
+    assertFalse( sql.getSelectFields().isDistinct() );
+    List<SQLField> selectFields = sql.getSelectFields().getFields();
+    assertEquals( 4, selectFields.size() );
+    assertEquals( "Category", selectFields.get( 0 ).getField() );
+    assertEquals( "Country", selectFields.get( 1 ).getField() );
+    assertEquals( "products_sold", selectFields.get( 2 ).getField() );
+    assertEquals( "sales_amount", selectFields.get( 3 ).getField() );
+  }
+
+  /**
+   * Tests schema."table" format
+   *
+   * @throws KettleSQLException
+   */
+  public void testSql10() throws KettleSQLException {
+    RowMetaInterface rowMeta = generateServiceRowMeta();
+
+    String sqlString = "SELECT Category, Country, products_sold, sales_amount FROM Kettle.\"Service\"";
+
+    SQL sql = new SQL( ThinUtil.stripNewlines( sqlString ) );
+
+    assertEquals( "Kettle", sql.getNamespace() );
+    assertEquals( "Service", sql.getServiceName() );
+    sql.parse( rowMeta );
+
+    assertFalse( sql.getSelectFields().isDistinct() );
+    List<SQLField> selectFields = sql.getSelectFields().getFields();
+    assertEquals( 4, selectFields.size() );
+    assertEquals( "Category", selectFields.get( 0 ).getField() );
+    assertEquals( "Country", selectFields.get( 1 ).getField() );
+    assertEquals( "products_sold", selectFields.get( 2 ).getField() );
+    assertEquals( "sales_amount", selectFields.get( 3 ).getField() );
+  }
+
+  /**
+   * Tests "schema".table format
+   *
+   * @throws KettleSQLException
+   */
+  public void testSql11() throws KettleSQLException {
+    RowMetaInterface rowMeta = generateServiceRowMeta();
+
+    String sqlString = "SELECT Category, Country, products_sold, sales_amount FROM \"Kettle\".Service";
+
+    SQL sql = new SQL( ThinUtil.stripNewlines( sqlString ) );
+
+    assertEquals( "Kettle", sql.getNamespace() );
+    assertEquals( "Service", sql.getServiceName() );
+    sql.parse( rowMeta );
+
+    assertFalse( sql.getSelectFields().isDistinct() );
+    List<SQLField> selectFields = sql.getSelectFields().getFields();
+    assertEquals( 4, selectFields.size() );
+    assertEquals( "Category", selectFields.get( 0 ).getField() );
+    assertEquals( "Country", selectFields.get( 1 ).getField() );
+    assertEquals( "products_sold", selectFields.get( 2 ).getField() );
+    assertEquals( "sales_amount", selectFields.get( 3 ).getField() );
+  }
+
+  /**
+   * Tests "schema"."table" format
+   *
+   * @throws KettleSQLException
+   */
+  public void testSql12() throws KettleSQLException {
+    RowMetaInterface rowMeta = generateServiceRowMeta();
+
+    String sqlString = "SELECT Category, Country, products_sold, sales_amount FROM \"Kettle\".\"Service\"";
+
+    SQL sql = new SQL( ThinUtil.stripNewlines( sqlString ) );
+
+    assertEquals( "Kettle", sql.getNamespace() );
+    assertEquals( "Service", sql.getServiceName() );
+    sql.parse( rowMeta );
+
+    assertFalse( sql.getSelectFields().isDistinct() );
+    List<SQLField> selectFields = sql.getSelectFields().getFields();
+    assertEquals( 4, selectFields.size() );
+    assertEquals( "Category", selectFields.get( 0 ).getField() );
+    assertEquals( "Country", selectFields.get( 1 ).getField() );
+    assertEquals( "products_sold", selectFields.get( 2 ).getField() );
+    assertEquals( "sales_amount", selectFields.get( 3 ).getField() );
+  }
+
+  /**
+   * Tests quoting in literal strings
+   *
+   * @throws KettleSQLException
+   */
+  public void testSql13() throws KettleSQLException {
+    RowMetaInterface rowMeta = generateGettingStartedRowMeta();
+
+    String sqlString =
+      "SELECT * FROM \"GETTING_STARTED\" WHERE \"GETTING_STARTED\".\"CUSTOMERNAME\" = 'ANNA''S DECORATIONS, LTD'";
+
+    SQL sql = new SQL( ThinUtil.stripNewlines( sqlString ) );
+
+    assertEquals( "GETTING_STARTED", sql.getServiceName() );
+    sql.parse( rowMeta );
+
+    assertNotNull( sql.getWhereCondition() );
+    assertEquals( "CUSTOMERNAME", sql.getWhereCondition().getCondition().getLeftValuename() );
+    assertEquals( "ANNA'S DECORATIONS, LTD", sql.getWhereCondition().getCondition().getRightExactString() );
+
+  }
+
+  /**
+   * Tests empty literal strings
+   *
+   * @throws KettleSQLException
+   */
+  public void testSql14() throws KettleSQLException {
+    RowMetaInterface rowMeta = generateGettingStartedRowMeta();
+
+    String sqlString = "SELECT * FROM \"GETTING_STARTED\" WHERE \"GETTING_STARTED\".\"CUSTOMERNAME\" = ''";
+
+    SQL sql = new SQL( ThinUtil.stripNewlines( sqlString ) );
+
+    assertEquals( "GETTING_STARTED", sql.getServiceName() );
+    sql.parse( rowMeta );
+
+    assertNotNull( sql.getWhereCondition() );
+    assertEquals( "CUSTOMERNAME", sql.getWhereCondition().getCondition().getLeftValuename() );
+    assertEquals( "", sql.getWhereCondition().getCondition().getRightExactString() );
+
+  }
+
+  /**
+   * Tests crazy quoting in literal strings
+   *
+   * @throws KettleSQLException
+   */
+  public void testSql15() throws KettleSQLException {
+    RowMetaInterface rowMeta = generateGettingStartedRowMeta();
+
+    String sqlString =
+      "SELECT * FROM \"GETTING_STARTED\" WHERE \"GETTING_STARTED\".\"CUSTOMERNAME\" = ''''''''''''";
+
+    SQL sql = new SQL( ThinUtil.stripNewlines( sqlString ) );
+
+    assertEquals( "GETTING_STARTED", sql.getServiceName() );
+    sql.parse( rowMeta );
+
+    assertNotNull( sql.getWhereCondition() );
+    assertEquals( "CUSTOMERNAME", sql.getWhereCondition().getCondition().getLeftValuename() );
+    assertEquals( "'''''", sql.getWhereCondition().getCondition().getRightExactString() );
+
+  }
+
+  /**
+   * Tests quoting in literal strings in IN clause
+   *
+   * @throws KettleSQLException
+   */
+  public void testSql16() throws KettleSQLException {
+    RowMetaInterface rowMeta = generateGettingStartedRowMeta();
+
+    String sqlString =
+      "SELECT * FROM \"GETTING_STARTED\" WHERE \"GETTING_STARTED\".\"CUSTOMERNAME\" IN ('ANNA''S DECORATIONS, LTD', 'MEN ''R'' US RETAILERS, Ltd.' )";
+
+    SQL sql = new SQL( ThinUtil.stripNewlines( sqlString ) );
+
+    assertEquals( "GETTING_STARTED", sql.getServiceName() );
+    sql.parse( rowMeta );
+
+    assertNotNull( sql.getWhereCondition() );
+    assertEquals( "CUSTOMERNAME", sql.getWhereCondition().getCondition().getLeftValuename() );
+    assertEquals( "ANNA'S DECORATIONS, LTD;MEN 'R' US RETAILERS, Ltd.", sql
+      .getWhereCondition().getCondition().getRightExactString() );
+
+  }
+
+  /**
+   * Tests semi-coluns and quoting in literal strings in IN clause
+   *
+   * @throws KettleSQLException
+   */
+  public void testSql17() throws KettleSQLException {
+    RowMetaInterface rowMeta = generateGettingStartedRowMeta();
+
+    String sqlString =
+      "SELECT * FROM \"GETTING_STARTED\" WHERE \"GETTING_STARTED\".\"CUSTOMERNAME\" IN ('ANNA''S DECORATIONS; LTD', 'MEN ''R'' US RETAILERS; Ltd.' )";
+
+    SQL sql = new SQL( ThinUtil.stripNewlines( sqlString ) );
+
+    assertEquals( "GETTING_STARTED", sql.getServiceName() );
+    sql.parse( rowMeta );
+
+    assertNotNull( sql.getWhereCondition() );
+    assertEquals( "CUSTOMERNAME", sql.getWhereCondition().getCondition().getLeftValuename() );
+    assertEquals( "ANNA'S DECORATIONS\\; LTD;MEN 'R' US RETAILERS\\; Ltd.", sql
+      .getWhereCondition().getCondition().getRightExactString() );
+
+  }
+
+  public void testSql18() throws KettleSQLException {
+
+    String sqlString = "SELECT A, B, C\nFROM Service\nWHERE B > 5\nORDER BY B DESC\nLIMIT 5    OFFSET    10";
+    SQL sql = new SQL( sqlString );
+    RowMetaInterface rowMeta = generateTest4RowMeta();
+    sql.parse( rowMeta );
+
+    assertEquals( 5, sql.getLimitValues().getLimit() );
+    assertEquals( 10, sql.getLimitValues().getOffset() );
+
+    sqlString = "SELECT A, B, C\nFROM Service\nWHERE B > 5\nORDER BY B DESC\nLIMIT 10, 5";
+    sql = new SQL( sqlString );
+    rowMeta = generateTest4RowMeta();
+    sql.parse( rowMeta );
+
+    assertEquals( 5, sql.getLimitValues().getLimit() );
+    assertEquals( 10, sql.getLimitValues().getOffset() );
+
+    sqlString = "SELECT A, B, C\nFROM Service\nWHERE B > 5\nORDER BY B DESC\nLIMIT 5";
+    sql = new SQL( sqlString );
+    rowMeta = generateTest4RowMeta();
+    sql.parse( rowMeta );
+
+    assertEquals( 5, sql.getLimitValues().getLimit() );
+
+    sqlString = "SELECT A, B, C\nFROM Service\nWHERE B > 5\nORDER BY B DESC\nLIMIT ERROR5";
+    sql = new SQL( sqlString );
+    rowMeta = generateTest4RowMeta();
+
+    try {
+      sql.parse( rowMeta );
+      fail();
+    } catch ( KettleSQLException e ) {
+      // Should throw a KettleSQLException
+    }
+  }
+
+  public static RowMetaInterface generateTest2RowMeta() {
+    RowMetaInterface rowMeta = new RowMeta();
+    rowMeta.addValueMeta( new ValueMeta( "A", ValueMetaInterface.TYPE_STRING, 50 ) );
+    rowMeta.addValueMeta( new ValueMeta( "B", ValueMetaInterface.TYPE_INTEGER, 7 ) );
+    return rowMeta;
+  }
+
+  public static RowMetaInterface generateTest3RowMeta() {
+    RowMetaInterface rowMeta = new RowMeta();
+    rowMeta.addValueMeta( new ValueMeta( "A", ValueMetaInterface.TYPE_STRING, 50 ) );
+    rowMeta.addValueMeta( new ValueMeta( "B", ValueMetaInterface.TYPE_INTEGER, 7 ) );
+    rowMeta.addValueMeta( new ValueMeta( "C", ValueMetaInterface.TYPE_INTEGER, 7 ) );
+    return rowMeta;
+  }
+
+  public static RowMetaInterface generateTest4RowMeta() {
+    RowMetaInterface rowMeta = new RowMeta();
+    rowMeta.addValueMeta( new ValueMeta( "A", ValueMetaInterface.TYPE_STRING, 50 ) );
+    rowMeta.addValueMeta( new ValueMeta( "B", ValueMetaInterface.TYPE_INTEGER, 7 ) );
+    rowMeta.addValueMeta( new ValueMeta( "C", ValueMetaInterface.TYPE_STRING, 50 ) );
+    rowMeta.addValueMeta( new ValueMeta( "D", ValueMetaInterface.TYPE_INTEGER, 7 ) );
+    return rowMeta;
+  }
+
+  public static RowMetaInterface generateServiceRowMeta() {
+    RowMetaInterface rowMeta = new RowMeta();
+    rowMeta.addValueMeta( new ValueMeta( "Category", ValueMetaInterface.TYPE_STRING, 50 ) );
+    rowMeta.addValueMeta( new ValueMeta( "Country", ValueMetaInterface.TYPE_INTEGER, 7 ) );
+    rowMeta.addValueMeta( new ValueMeta( "products_sold", ValueMetaInterface.TYPE_INTEGER, 7 ) );
+    rowMeta.addValueMeta( new ValueMeta( "sales_amount", ValueMetaInterface.TYPE_NUMBER, 7, 2 ) );
+    return rowMeta;
+  }
+
+  public static RowMetaInterface generateZipsRowMeta() {
+    RowMetaInterface rowMeta = new RowMeta();
+    rowMeta.addValueMeta( new ValueMeta( "zip", ValueMetaInterface.TYPE_STRING, 5 ) );
+    rowMeta.addValueMeta( new ValueMeta( "city", ValueMetaInterface.TYPE_INTEGER, 50 ) );
+    rowMeta.addValueMeta( new ValueMeta( "state", ValueMetaInterface.TYPE_STRING, 2 ) );
+    rowMeta.addValueMeta( new ValueMeta( "rows", ValueMetaInterface.TYPE_INTEGER, 1 ) );
+    return rowMeta;
+  }
+
+  public static RowMetaInterface generateGettingStartedRowMeta() {
+    RowMetaInterface rowMeta = new RowMeta();
+    rowMeta.addValueMeta( new ValueMeta( "CUSTOMERNAME", ValueMetaInterface.TYPE_STRING, 50 ) );
+    rowMeta.addValueMeta( new ValueMeta( "MONTH_ID", ValueMetaInterface.TYPE_INTEGER, 4 ) );
+    rowMeta.addValueMeta( new ValueMeta( "YEAR_ID", ValueMetaInterface.TYPE_INTEGER, 2 ) );
+    rowMeta.addValueMeta( new ValueMeta( "STATE", ValueMetaInterface.TYPE_STRING, 30 ) );
+    return rowMeta;
+  }
+
+  public static RowMetaInterface mockRowMeta( String... fieldNames ) {
+    RowMetaInterface rowMeta = mock( RowMetaInterface.class );
+    for ( String field : fieldNames ) {
+      ValueMetaInterface valueMeta = mock( ValueMetaInterface.class );
+      when( valueMeta.getName() ).thenReturn( field );
+      when( rowMeta.searchValueMeta( field ) )
+        .thenReturn( valueMeta );
+    }
+    return rowMeta;
+  }
+}


### PR DESCRIPTION
Moving org.pentaho.di.core.sql and org.pentaho.di.core.jdbc leftovers here.
