### PR TITLE
[BACKLOG-5453] Add the field "webapp name" for Pentaho Data Service database type (SWT Dialog)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 .classpath
 .settings/
 *.iml
+.idea/

--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/client/DataServiceClientPlugin.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/client/DataServiceClientPlugin.java
@@ -30,9 +30,6 @@ import org.pentaho.di.core.row.ValueMetaInterface;
 import org.pentaho.di.trans.dataservice.jdbc.ThinConnection;
 import org.pentaho.di.trans.dataservice.jdbc.ThinDriver;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Contains the wrapper for the Kettle Think JDBC driver database connection information through static final members
  *
@@ -49,7 +46,7 @@ public class DataServiceClientPlugin extends BaseDatabaseMeta implements Databas
   @Override
   public int[] getAccessTypeList() {
     return new int[] {
-      DatabaseMeta.TYPE_ACCESS_NATIVE, DatabaseMeta.TYPE_ACCESS_ODBC, DatabaseMeta.TYPE_ACCESS_JNDI };
+      DatabaseMeta.TYPE_ACCESS_NATIVE, DatabaseMeta.TYPE_ACCESS_JNDI };
   }
 
   @Override
@@ -59,20 +56,17 @@ public class DataServiceClientPlugin extends BaseDatabaseMeta implements Databas
 
   @Override
   public String getURL( String hostname, String port, String databaseName ) {
-    return ThinDriver.BASE_URL + hostname + ":" + port + ThinDriver.SERVICE_NAME;
+    StringBuilder url = new StringBuilder( ThinDriver.BASE_URL + hostname + ":" + port );
+
+    if ( getAttributes().containsKey( ThinConnection.ARG_WEB_APPLICATION_NAME ) ) {
+      url.append( '/' ).append( getAttributes().getProperty( ThinConnection.ARG_WEB_APPLICATION_NAME ) );
+    }
+
+    return url.append( ThinDriver.SERVICE_NAME ).toString();
   }
 
   @Override public int getDefaultDatabasePort() {
     return 9080;
-  }
-
-  @Override public Map<String, String> getDefaultOptions() {
-    final String prefix = getPluginId() + ".";
-    HashMap<String, String> defaults = new HashMap<String, String>();
-
-    defaults.put( prefix + ThinConnection.ARG_WEBAPPNAME, DEFAULT_WEBAPPNAME );
-
-    return defaults;
   }
 
   @Override public String getDatabaseName() {

--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/ThinConnection.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/ThinConnection.java
@@ -71,6 +71,7 @@ public class ThinConnection extends ThinBase implements Connection {
   public static final String ARG_DEBUGTRANS = "debugtrans";
   public static final String ARG_ISSECURE = "secure";
   public static final String ARG_LOCAL = "local";
+  public static final String ARG_WEB_APPLICATION_NAME = "WEB_APPLICATION_NAME";
 
   public static DataServiceClientService localClient;
   private DataServiceClientService clientService;

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/client/DataServiceClientPluginTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/client/DataServiceClientPluginTest.java
@@ -22,9 +22,10 @@
 
 package org.pentaho.di.trans.dataservice.client;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
+import java.lang.reflect.Method;
+import java.net.URL;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,15 +34,11 @@ import org.pentaho.di.core.database.DatabaseInterface;
 import org.pentaho.di.core.database.DatabaseMeta;
 import org.pentaho.di.core.plugins.DatabaseMetaPlugin;
 import org.pentaho.di.core.row.ValueMetaInterface;
+import org.pentaho.di.trans.dataservice.jdbc.ThinConnection;
 import org.pentaho.di.trans.dataservice.jdbc.ThinDriver;
-
-import java.lang.reflect.Method;
-import java.net.URL;
-import java.util.Map;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyArray;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -104,7 +101,7 @@ public class DataServiceClientPluginTest {
   @Test
   public void testDriverProperties() throws Exception {
     assertThat( Ints.asList( clientPlugin.getAccessTypeList() ), containsInAnyOrder(
-      DatabaseMeta.TYPE_ACCESS_NATIVE, DatabaseMeta.TYPE_ACCESS_ODBC, DatabaseMeta.TYPE_ACCESS_JNDI
+      DatabaseMeta.TYPE_ACCESS_NATIVE, DatabaseMeta.TYPE_ACCESS_JNDI
     ) );
 
     assertThat( clientPlugin.getUsedLibraries(), emptyArray() );
@@ -116,9 +113,6 @@ public class DataServiceClientPluginTest {
     clientPlugin.setDatabaseName( "override" );
     assertThat( clientPlugin.getDatabaseName(), is( "kettle" ) );
 
-    Map<String, String> expectedDefaults = ImmutableMap.of( "KettleThin.webappname", "pentaho-di" );
-    assertThat( clientPlugin.getDefaultOptions(), equalTo( expectedDefaults ) );
-
     assertThat( clientPlugin.getExtraOptionIndicator(), is( "?" ) );
     assertThat( clientPlugin.getExtraOptionSeparator(), is( "&" ) );
   }
@@ -126,5 +120,7 @@ public class DataServiceClientPluginTest {
   @Test
   public void testConstructURL() throws Exception {
     assertThat( clientPlugin.getURL( "host.com", "8080", "kettle" ), is( "jdbc:pdi://host.com:8080/kettle" ) );
+    clientPlugin.getAttributes().put( ThinConnection.ARG_WEB_APPLICATION_NAME, "pentaho-di" );
+    assertThat( clientPlugin.getURL( "host.com", "8080", "kettle" ), is( "jdbc:pdi://host.com:8080/pentaho-di/kettle" ) );
   }
 }


### PR DESCRIPTION
Remove unnecessary code, change the way connect URL is constructed.

Kettle part is in https://github.com/pentaho/pentaho-kettle/pull/2412
@hudak 
