### PR TITLE
[BACKLOG-10097] As a new user to Pentaho and creating a connection to…

### DIFF
--- a/assembly/README.txt
+++ b/assembly/README.txt
@@ -1,6 +1,3 @@
+The pdi-dataservice-client zip contains all of the jar files required to make a JDBC connection to a running Data Service.
 
-The pdi-dataservice-client zip contains all of the jar files required to make
-a JDBC connection to a running Data Service.
-
-Configuration documentation can be found at
-https://help.pentaho.com/Documentation/6.1/0L0/0Y0/090/040
+Configuration documentation can be found at https://help.pentaho.com/Documentation/7.0/0L0/0Y0/090/040

--- a/doc/techOverview.md
+++ b/doc/techOverview.md
@@ -120,7 +120,7 @@ Hosting Data Services from **Carte** is not yet officially supported.
 ## User Guide
 
 ### SQL Queries
-Data Services support a limited subset of SQL.  The capabilities are documented here: [6.0](http://help.pentaho.com/Documentation/6.0/0L0/0Y0/090/080), [6.1](http://help.pentaho.com/Documentation/6.1/0L0/0Y0/090/080)
+Data Services support a limited subset of SQL.  The capabilities are documented here: [6.0](http://help.pentaho.com/Documentation/6.0/0L0/0Y0/090/080), [6.1](http://help.pentaho.com/Documentation/6.1/0L0/0Y0/090/080), [7.0](http://help.pentaho.com/Documentation/7.0/0L0/0Y0/090/080
 
 
 **Some important things to keep in mind:**

--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/client/DataServiceClientPlugin.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/client/DataServiceClientPlugin.java
@@ -69,7 +69,7 @@ public class DataServiceClientPlugin extends BaseDatabaseMeta implements Databas
   }
 
   @Override public String getExtraOptionsHelpText() {
-    return "https://help.pentaho.com/Documentation/6.1/0L0/0Y0/090/040";
+    return "https://help.pentaho.com/Documentation/7.0/0L0/0Y0/090/040";
   }
 
   @Override


### PR DESCRIPTION
… Pentaho Data Services, I want the default web-app name for the Data Service driver to use 'pentaho' instead of 'pentaho-di' since there is no such web-app in 7.0
@mkambol @hudak 
