### PR TITLE
[BACKLOG-14810] When determining the field name when it is apart of a…

### DIFF
--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLField.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLField.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2013 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -125,8 +125,8 @@ public class SQLField {
               throw new KettleSQLException( "No opening bracket found after keyword ["
                 + aggregation.getKeyWord() + "] in clause [" + fieldClause + "]" );
             }
-            int closeIndex = value.indexOf( ')', openIndex );
-            if ( closeIndex < 0 ) {
+            int closeIndex = value.lastIndexOf( ')' );
+            if ( closeIndex <= openIndex ) {
               throw new KettleSQLException( "No closing bracket found after keyword ["
                 + aggregation.getKeyWord() + "]" );
             }

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLFieldTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLFieldTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -396,6 +396,17 @@ public class SQLFieldTest extends TestCase {
     assertEquals( "B", condition.getLeftValuename() );
     assertEquals( ">", condition.getFunctionDesc() );
     assertEquals( "50", condition.getRightExactString() );
+  }
+
+  public void testAliasWithParans() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateTest2RowMetaWithParans();
+
+    String fieldClause = "sum(\"Service\".\"B (g)\") as nrSize";
+
+    SQLField field = new SQLField( "Service", fieldClause, rowMeta );
+    assertEquals( "B (g)", field.getName() );
+    assertEquals( "nrSize", field.getAlias() );
+    assertEquals( SQLAggregation.SUM, field.getAggregation() );
   }
 
   public void testSqlFieldConstants01() throws KettleSQLException {

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -492,6 +492,13 @@ public class SQLTest extends TestCase {
     RowMetaInterface rowMeta = new RowMeta();
     rowMeta.addValueMeta( new ValueMeta( "A", ValueMetaInterface.TYPE_STRING, 50 ) );
     rowMeta.addValueMeta( new ValueMeta( "B", ValueMetaInterface.TYPE_INTEGER, 7 ) );
+    return rowMeta;
+  }
+
+  public static RowMetaInterface generateTest2RowMetaWithParans() {
+    RowMetaInterface rowMeta = new RowMeta();
+    rowMeta.addValueMeta( new ValueMeta( "A", ValueMetaInterface.TYPE_STRING, 50 ) );
+    rowMeta.addValueMeta( new ValueMeta( "B (g)", ValueMetaInterface.TYPE_INTEGER, 7 ) );
     return rowMeta;
   }
 


### PR DESCRIPTION
…n aggregation and the field name contains '(' or ')', full field name will not be retrieved based on how the closing ')' is retrieved.