### PR TITLE
[BACKLOG-16068] - Windows 10: DET - After Persistence - Flat Table Se…

### DIFF
--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/ThinResultSet.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/ThinResultSet.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -151,7 +151,9 @@ public class ThinResultSet extends BaseResultSet {
       return data;
     } catch ( KettleFileException e ) {
       size = getRow();
-      dataInputStream.close();
+      if ( dataInputStream != null ) {
+        dataInputStream.close();
+      }
       return null;
     }
   }

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/ThinResultSetTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/ThinResultSetTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2016 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -139,6 +139,12 @@ public class ThinResultSetTest extends BaseResultSetTest {
     verify( rowMeta ).readData( dataInputStream );
     assertThat( thinResultSet.next(), is( false ) );
     verifyNoMoreInteractions( rowMeta );
+  }
+
+  @Test
+  public void testNullDataInputStream() throws Exception {
+    doThrow( new KettleFileException() ).when( rowMeta ).readData( null );
+    verify( dataInputStream, never() ).close();
   }
 
   @Test


### PR DESCRIPTION
…lected and Pivot Table ( Drilldown ) - ERROR [d] java.lang.NullPointerException

- added null check on close data stream 