### PR TITLE
[BACKLOG-16068, FIX] - Windows 10: DET - After Persistence - Flat Tab…

### DIFF
--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/ThinResultSet.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/ThinResultSet.java
@@ -151,7 +151,7 @@ public class ThinResultSet extends BaseResultSet {
       return data;
     } catch ( KettleFileException e ) {
       size = getRow();
-      if ( dataInputStream != null ) {
+      if ( !isClosed() ) {
         dataInputStream.close();
       }
       return null;

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/ThinResultSetTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/ThinResultSetTest.java
@@ -143,7 +143,15 @@ public class ThinResultSetTest extends BaseResultSetTest {
 
   @Test
   public void testNullDataInputStream() throws Exception {
-    doThrow( new KettleFileException() ).when( rowMeta ).readData( null );
+    ThinResultSet thinResultSetSpy = spy( thinResultSet );
+    doThrow( new KettleFileException() ).when( rowMeta ).readData( any( java.io.DataInputStream.class) );
+
+    doReturn( true ).when( thinResultSetSpy ).isClosed();
+    doReturn( true ).when( thinResultSetSpy ).isAfterLast();
+    doReturn( 5 ).when( thinResultSetSpy ).size();
+    doReturn( 0 ).when( thinResultSetSpy ).getRow();
+
+    thinResultSetSpy.retrieveRow( 1 );
     verify( dataInputStream, never() ).close();
   }
 


### PR DESCRIPTION
…le Selected and Pivot Table ( Drilldown ) - ERROR [d] java.lang.NullPointerException

- updated null check
- updated test