### PR TITLE
[BACKLOG-18470] Equals in a HAVING clause mishandled

### DIFF
--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/core/jdbc/FoundClause.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/core/jdbc/FoundClause.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2014 by Pentaho : http://www.pentaho.com
+ * Copyright (C) 2002-2017 by Pentaho : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -22,13 +22,6 @@
 
 package org.pentaho.di.core.jdbc;
 
-/**
- * This class is no longer used
- *
- * Data Service client code is now available in the pdi-dataservice-plugin project
- *
- */
-@Deprecated
 public class FoundClause {
   private final String clause;
   private final String rest;

--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/core/jdbc/ThinUtil.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/core/jdbc/ThinUtil.java
@@ -49,13 +49,6 @@ import org.pentaho.di.core.row.value.ValueMetaNumber;
 import org.pentaho.di.core.row.value.ValueMetaString;
 import org.pentaho.di.core.xml.XMLHandler;
 
-/**
- * Static methods provided by this class should be copied to their respective projects
- *
- * Data Service client code is now available in the pdi-dataservice-plugin project
- *
- */
-@Deprecated
 public class ThinUtil {
 
   public static String stripNewlines( String sql ) {

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLConditionTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLConditionTest.java
@@ -32,7 +32,6 @@ import java.util.List;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.pentaho.di.core.sql.SQLTest.mockRowMeta;
 
 public class SQLConditionTest extends TestCase {
@@ -986,5 +985,18 @@ public class SQLConditionTest extends TestCase {
     assertThat( children.get( 1 ).getFunctionDesc(), is( ">" ) );
     assertThat( children.get( 1 ).getLeftValuename(), is( "Space Field" ) );
     assertTrue( condition.isComposite() );
+  }
+
+  @Test
+  public void testHavingConditionWithEquals() throws KettleSQLException {
+    RowMetaInterface rowMeta = mockRowMeta( "Led Zeppelin", "Rulz!" );
+
+    SQLCondition sqlCondition = new SQLCondition(
+      "table", "SUM('Led Zeppelin') = 0", rowMeta );
+    Condition condition = sqlCondition.getCondition();
+    assertThat( condition.getFunctionDesc(), is( "=" ) );
+    assertThat( condition.getLeftValuename(), is( "SUM('Led Zeppelin')" ) );
+    assertThat( condition.getRightExact().getValueData(), is( 0l ) );
+    assertTrue( condition.isAtomic() );
   }
 }


### PR DESCRIPTION
[BACKLOG-18470] Equals in a HAVING clause mishandled

Added a check of the expression element to determine whether
it appears to be an aggregate expression, using the same criteria
from SQLField (it starts with one of the func names, followed by an
open param).

Redesigning dataservices to use a parser is the real way to
address these sorts of bugs, and will save the lives of countless
kittens.

http://jira.pentaho.com/browse/BACKLOG-18470