### PR TITLE
[BACKLOG-19534] - DET: Date type fields show incorrect results after …

### DIFF
--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLCondition.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLCondition.java
@@ -281,15 +281,7 @@ public class SQLCondition {
 
         part = Const.trim( part );
 
-        // Remove the quotes around the string...
-        //
-        if ( part.startsWith( "'" ) && part.endsWith( "'" ) ) {
-          part = part.substring( 1, part.length() - 1 );
-        }
-
-        // Undo escaping...
-        //
-        part = part.replace( "''", "'" );
+        part = ThinUtil.extractConstant( part ).toString();
 
         // Escape semi-colons
         //

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLConditionTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLConditionTest.java
@@ -916,6 +916,28 @@ public class SQLConditionTest extends TestCase {
     assertEquals( "'\\;';Toys 'R' us", condition.getRightExactString() );
   }
 
+  public void testCondition31() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateGettingStartedRowMeta();
+
+    String fieldsClause = "ORDERDATE";
+    String conditionClause = "ORDERDATE IN (DATE '2004-01-15', DATE '2004-02-20', DATE '2004-05-18')"; // BACKLOG-19534
+
+    // Correctness of the next statement is tested in SQLFieldsTest
+    //
+    SQLFields fields = new SQLFields( "Service", rowMeta, fieldsClause );
+
+    SQLCondition sqlCondition = new SQLCondition( "Service", conditionClause, rowMeta, fields );
+    Condition condition = sqlCondition.getCondition();
+
+    assertNotNull( condition );
+    assertFalse( condition.isEmpty() );
+    assertTrue( condition.isAtomic() );
+    assertEquals( Condition.FUNC_IN_LIST, condition.getFunction() );
+
+    assertEquals( "ORDERDATE", condition.getLeftValuename() );
+    assertEquals( "2004-01-15;2004-02-20;2004-05-18", condition.getRightExactString() );
+  }
+
   @Test
   public void testNegatedTrueFuncEvaluatesAsFalse() throws Exception {
     RowMetaInterface rowMeta = SQLTest.generateServiceRowMeta();

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLTest.java
@@ -631,6 +631,7 @@ public class SQLTest extends TestCase {
     rowMeta.addValueMeta( new ValueMeta( "MONTH_ID", ValueMetaInterface.TYPE_INTEGER, 4 ) );
     rowMeta.addValueMeta( new ValueMeta( "YEAR_ID", ValueMetaInterface.TYPE_INTEGER, 2 ) );
     rowMeta.addValueMeta( new ValueMeta( "STATE", ValueMetaInterface.TYPE_STRING, 30 ) );
+    rowMeta.addValueMeta( new ValueMeta( "ORDERDATE", ValueMetaInterface.TYPE_DATE, 60 ) );
     return rowMeta;
   }
 


### PR DESCRIPTION
…applying filters in Model View

In case when mondrian-builded SQL-query has 1 row in a tuple:
`select 
"test"."TERRITORY" as "c0", 
"test"."ORDERDATE" as "c1" 
from "Kettle"."test" as "test" 
where ("test"."ORDERDATE" = DATE '2005-04-08') 
group by 
"test"."TERRITORY", 
"test"."ORDERDATE" 
order by 
CASE WHEN "test"."TERRITORY" IS NULL THEN 1 ELSE 0 END, 
"test"."TERRITORY" ASC, CASE WHEN "test"."ORDERDATE" IS NULL THEN 1 ELSE 0 END, 
"test"."ORDERDATE" ASC`
value '2005-04-05' is extracted from [DATE '2005-04-05']
https://github.com/pentaho/pdi-dataservice-plugin/blob/master/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLCondition.java#L324
Result of execution is correct

In case when mondrian-builded SQL-query has few rows in a tuple:
`select 
"test"."TERRITORY" as "c0", 
"test"."ORDERDATE" as "c1" 
from 
"Kettle"."test" as "test" 
where ("test"."ORDERDATE" in (DATE '2004-01-15', DATE '2004-02-20', DATE '2004-05-18')) 
group by 
"test"."TERRITORY", "test"."ORDERDATE" 
order by CASE WHEN "test"."TERRITORY" 
IS NULL THEN 1 ELSE 0 END, 
"test"."TERRITORY" ASC, 
CASE WHEN "test"."ORDERDATE" IS NULL THEN 1 ELSE 0 END, 
"test"."ORDERDATE" ASC`
Extraction is absent, [DATE '2004-01-15', DATE '2004-02-20', DATE '2004-05-18'] is passed further
At this place exception is thrown:
https://github.com/pentaho/pdi-dataservice-server-plugin/blob/master/src/main/java/org/pentaho/di/trans/dataservice/optimization/ValueMetaResolver.java#L137
It expects ['2004-01-15', '2004-02-20', '2004-05-18'], not [DATE '2004-01-15', DATE '2004-02-20', DATE '2004-05-18']

As for "Remove the quotes around the string..." and " // Undo escaping..." - this code already exists in ThinUtil.extractConstant( part ) -> attemptStringValueExtraction(...)
https://github.com/pentaho/pdi-dataservice-plugin/blob/master/pdi-dataservice-client/src/main/java/org/pentaho/di/core/jdbc/ThinUtil.java#L274-L279
