### PR TITLE
[PDI-16804] DET charts can show no data, when it should show data

### DIFF
--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/core/jdbc/ThinUtil.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/core/jdbc/ThinUtil.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -160,15 +160,12 @@ public class ThinUtil {
       String unquoted = string.substring( 1, string.length() - 1 );
       if ( unquoted.length() >= 9 && unquoted.charAt( 4 ) == '/' && unquoted.charAt( 7 ) == '/' ) {
         Date date = XMLHandler.stringToDate( unquoted );
-        String format = "yyyy/MM/dd HH:mm:ss.SSS";
         if ( date == null ) {
           try {
             date = new SimpleDateFormat( "yyyy/MM/dd HH:mm:ss" ).parse( unquoted );
-            format = "yyyy/MM/dd HH:mm:ss";
           } catch ( ParseException e1 ) {
             try {
               date = new SimpleDateFormat( "yyyy/MM/dd" ).parse( unquoted );
-              format = "yyyy/MM/dd";
             } catch ( ParseException e2 ) {
               date = null;
             }
@@ -176,7 +173,8 @@ public class ThinUtil {
         }
         if ( date != null ) {
           ValueMetaInterface valueMeta = new ValueMeta( "iif-date", ValueMetaInterface.TYPE_DATE );
-          valueMeta.setConversionMask( format );
+          // default conversion mask is used for data saving irrespective of locale differences
+          valueMeta.setConversionMask( ValueMetaAndData.VALUE_REPOSITORY_DATE_CONVERSION_MASK );
           return new ValueMetaAndData( valueMeta, date );
         }
       }
@@ -202,7 +200,8 @@ public class ThinUtil {
           }
           if ( date != null ) {
             ValueMetaInterface valueMeta = new ValueMeta( "iff-date", ValueMetaInterface.TYPE_DATE );
-            valueMeta.setConversionMask( format );
+            // default conversion mask is used for data saving irrespective of locale differences
+            valueMeta.setConversionMask( ValueMetaAndData.VALUE_REPOSITORY_DATE_CONVERSION_MASK );
             return new ValueMetaAndData( valueMeta, date );
           }
         }

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/core/jdbc/ThinUtilTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/core/jdbc/ThinUtilTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Data Integration
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  *******************************************************************************
  *
@@ -34,7 +34,12 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -66,15 +71,15 @@ public class ThinUtilTest {
 
   @SuppressWarnings( "deprecation" )
   @Test
-  public void testAttemptDateValueExtraction() throws Exception {
+  public void testAttemptDateValueExtraction() {
     ValueMetaAndData timestamp = ThinUtil.attemptDateValueExtraction( "TIMESTAMP '2014-01-01 00:00:00'" );
     ValueMetaAndData date = ThinUtil.attemptDateValueExtraction( "DATE '2014-01-01'" );
 
     assertNotNull( timestamp );
-    assertEquals( "2014-01-01 00:00:00", timestamp.toString() );
+    assertEquals( "2014/01/01 00:00:00.000", timestamp.toString() );
 
     assertNotNull( date );
-    assertEquals( "2014-01-01", date.toString() );
+    assertEquals( "2014/01/01 00:00:00.000", date.toString() );
   }
 
   @SuppressWarnings( "deprecation" )

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/client/DataServiceConnectionInformationTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/client/DataServiceConnectionInformationTest.java
@@ -2,7 +2,7 @@
  *
  * Pentaho Community Edition Project: data-refinery-pdi-plugin
  *
- * Copyright (C) 2002-2017 by Hitachi Vantara : http://www.pentaho.com
+ * Copyright (C) 2002-2018 by Hitachi Vantara : http://www.pentaho.com
  *
  * *******************************************************************************
  *
@@ -41,7 +41,6 @@ import org.pentaho.di.core.plugins.PluginTypeInterface;
 import org.pentaho.di.repository.IUser;
 import org.pentaho.di.repository.Repository;
 import org.pentaho.di.repository.RepositoryMeta;
-import org.pentaho.di.trans.dataservice.client.DataServiceClientPlugin;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -49,7 +48,10 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class DataServiceConnectionInformationTest {
   private static PluginInterface mockDbPlugin;
@@ -170,7 +172,7 @@ public class DataServiceConnectionInformationTest {
     DataServiceConnectionInformation connectInfo =
       new DataServiceConnectionInformation( dataServiceName, repository, log );
     assertLocalConnection( dataServiceName, connectInfo );
-    verify( log ).logDebug( "\n\"Element repository_location_url not found in Repository Meta XML\"\n" );
+    verify( log ).logDebug( Mockito.contains( "Element repository_location_url not found in Repository Meta XML" ) );
   }
 
   @Test


### PR DESCRIPTION
- parsing error for queries, which use new line instead of whitespace as separator, was fixed
- date conversion mask was set to the default yyyy/MM/dd HH:mm:ss.SSS due to the inconsistency between saved date and queried, which results in date mismatch
- some tests were changed and some were added