### PR TITLE
[SP-4025] - Backport of PDI-16835 - Dependency httpclient.jar missing…

### DIFF
--- a/assembly/src/main/descriptors/assembly.xml
+++ b/assembly/src/main/descriptors/assembly.xml
@@ -44,6 +44,7 @@
         <include>commons-lang:commons-lang:*</include>
         <include>commons-logging:commons-logging:*</include>
         <include>org.apache.httpcomponents:httpclient:*</include>
+		<include>org.apache.httpcomponents:httpcore:*</include>
         <include>net.sf.scannotation:scannotation:*</include>
         <include>log4j:log4j:jar:*</include>
         <include>javassist:javassist:*</include>


### PR DESCRIPTION
… from Pentaho Data Services Driver Bundle (8.0 Suite)