### PR TITLE
[PDI-16671]-"Something Went Wrong" error message shows up when trying  to Inspect Data which has a field name with Double Quotes.

### DIFF
--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLField.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLField.java
@@ -228,7 +228,7 @@ public class SQLField {
 
       } else {
         if ( valueMeta == null ) {
-          field = ThinUtil.resolveFieldName( ThinUtil.unQuote( field.replaceAll( "\"\"", "\"" ) ), serviceFields );
+          field = ThinUtil.resolveFieldName( ThinUtil.unQuote( field ).replaceAll( "\"\"", "\"" ), serviceFields );
           valueMeta = serviceFields.searchValueMeta( field );
           if ( orderField && selectFields != null ) {
             // See if this isn't an aliased select field that we're ordering on


### PR DESCRIPTION
 -additional fix. when we use the filed name with double quotes as measure