### PR TITLE
[BACKLOG-23281] - Support streaming parameters in the JDBC connection string

### DIFF
--- a/assemblies/driver/src/assembly/assembly.xml
+++ b/assemblies/driver/src/assembly/assembly.xml
@@ -44,12 +44,14 @@
         <include>commons-codec:commons-codec:*</include>
         <include>commons-lang:commons-lang:*</include>
         <include>commons-logging:commons-logging:*</include>
+        <include>commons-io:commons-io:*</include>
         <include>org.apache.httpcomponents:httpclient:*</include>
         <include>org.apache.httpcomponents:httpcore:*</include>
         <include>net.sf.scannotation:scannotation:*</include>
         <include>log4j:log4j:jar:*</include>
         <include>javassist:javassist:*</include>
         <include>com.google.guava:guava:*</include>
+        <include>org.slf4j:slf4j-api:*</include>
       </includes>
       <excludes>
       </excludes>

--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/RemoteClient.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/RemoteClient.java
@@ -98,11 +98,29 @@ class RemoteClient implements IDataServiceClientService, ConnectionAbortingSuppo
 
       method.getParams().setParameter( "http.socket.timeout", 0 );
 
+      String windowMode = connection.getWindowMode();
+      String windowSize = connection.getWindowSize();
+      String windowEvery = connection.getWindowEvery();
+      String windowLimit = connection.getWindowLimit();
+
       ArrayList<NameValuePair> postParameters = new ArrayList<NameValuePair>();
       // Kept in for backwards compatibility, but should be removed in next major release
       if ( sql.length() < MAX_SQL_LENGTH ) {
         method.addHeader( new BasicHeader( SQL, CharMatcher.anyOf( "\n\r" ).collapseFrom( sql, ' ' ) ) );
         method.addHeader( new BasicHeader( MAX_ROWS, Integer.toString( maxRows ) ) );
+
+        if ( !Strings.isNullOrEmpty( windowMode ) ) {
+          method.addHeader( new BasicHeader( WINDOW_MODE, windowMode ) );
+        }
+        if ( !Strings.isNullOrEmpty( windowSize ) ) {
+          method.addHeader( new BasicHeader( WINDOW_SIZE, windowSize ) );
+        }
+        if ( !Strings.isNullOrEmpty( windowEvery ) ) {
+          method.addHeader( new BasicHeader( WINDOW_EVERY, windowEvery ) );
+        }
+        if ( !Strings.isNullOrEmpty( windowLimit ) ) {
+          method.addHeader( new BasicHeader( WINDOW_LIMIT, windowLimit ) );
+        }
       }
 
       for ( Map.Entry<String, String> parameterEntry : connection.getParameters().entrySet() ) {
@@ -112,6 +130,19 @@ class RemoteClient implements IDataServiceClientService, ConnectionAbortingSuppo
       postParameters.add( new BasicNameValuePair( SQL, CharMatcher.anyOf( "\n\r" )
               .collapseFrom( sql, ' ' ) ) );
       postParameters.add( new BasicNameValuePair( MAX_ROWS, Integer.toString( maxRows ) ) );
+
+      if ( !Strings.isNullOrEmpty( windowMode ) ) {
+        postParameters.add( new BasicNameValuePair( WINDOW_MODE, windowMode ) );
+      }
+      if ( !Strings.isNullOrEmpty( windowSize ) ) {
+        postParameters.add( new BasicNameValuePair( WINDOW_SIZE, windowSize ) );
+      }
+      if ( !Strings.isNullOrEmpty( windowEvery ) ) {
+        postParameters.add( new BasicNameValuePair( WINDOW_EVERY, windowEvery ) );
+      }
+      if ( !Strings.isNullOrEmpty( windowLimit ) ) {
+        postParameters.add( new BasicNameValuePair( WINDOW_LIMIT, windowLimit ) );
+      }
 
       if ( !Strings.isNullOrEmpty( connection.getDebugTransFilename() ) ) {
         postParameters.add( new BasicNameValuePair( ThinConnection.ARG_DEBUGTRANS,

--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/ThinConnection.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/trans/dataservice/jdbc/ThinConnection.java
@@ -78,9 +78,10 @@ public class ThinConnection extends ThinBase implements Connection {
   public static final String ARG_ISSECURE = "secure";
   public static final String ARG_LOCAL = "local";
   public static final String ARG_MAX_ROWS = "maxrows";
-  public static final String ARG_WINDOW_ROW_SIZE = "windowrows";
-  public static final String ARG_WINDOW_TIME_SIZE = "windowtime";
-  public static final String ARG_WINDOW_UPDATE_RATE = "windowrate";
+  public static final String ARG_WINDOW_MODE = "windowmode";
+  public static final String ARG_WINDOW_SIZE = "windowsize";
+  public static final String ARG_WINDOW_EVERY = "windowevery";
+  public static final String ARG_WINDOW_LIMIT = "windowlimit";
   public static final String ARG_WEB_APPLICATION_NAME = BaseDatabaseMeta.ATTRIBUTE_PREFIX_EXTRA_OPTION
       + "KettleThin.webappname";
 
@@ -97,9 +98,10 @@ public class ThinConnection extends ThinBase implements Connection {
 
   // Streaming parameters
   private String maxRows;
-  private String windowRows;
-  private String windowTime;
-  private String windowRate;
+  private String windowMode;
+  private String windowSize;
+  private String windowEvery;
+  private String windowLimit;
 
   private String proxyHostname;
   private String proxyPort;
@@ -427,24 +429,31 @@ public class ThinConnection extends ThinBase implements Connection {
   }
 
   /**
-   * @return the windowRows
+   * @return the windowMode
    */
-  public String getWindowRows() {
-    return windowRows;
+  public String getWindowMode() {
+    return windowMode;
   }
 
   /**
-   * @return the windowTime
+   * @return the windowSize
    */
-  public String getWindowTime() {
-    return windowTime;
+  public String getWindowSize() {
+    return windowSize;
   }
 
   /**
-   * @return the windowRate
+   * @return the windowEvery
    */
-  public String getWindowRate() {
-    return windowRate;
+  public String getWindowEvery() {
+    return windowEvery;
+  }
+
+  /**
+   * @return the windowLimit
+   */
+  public String getWindowLimit() {
+    return windowLimit;
   }
 
   /**
@@ -505,9 +514,10 @@ public class ThinConnection extends ThinBase implements Connection {
 
   private ThinConnection extractProperties( Map<String, String> arguments ) {
     maxRows = arguments.get( ARG_MAX_ROWS );
-    windowRows = arguments.get( ARG_WINDOW_ROW_SIZE );
-    windowTime = arguments.get( ARG_WINDOW_TIME_SIZE );
-    windowRate = arguments.get( ARG_WINDOW_UPDATE_RATE );
+    windowMode = arguments.get( ARG_WINDOW_MODE );
+    windowSize = arguments.get( ARG_WINDOW_SIZE );
+    windowEvery = arguments.get( ARG_WINDOW_EVERY );
+    windowLimit = arguments.get( ARG_WINDOW_LIMIT );
     proxyHostname = arguments.get( ARG_PROXYHOSTNAME );
     proxyPort = arguments.get( ARG_PROXYPORT );
     nonProxyHosts = arguments.get( ARG_NONPROXYHOSTS );

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/ThinConnectionTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/trans/dataservice/jdbc/ThinConnectionTest.java
@@ -56,6 +56,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyMap;
@@ -85,9 +86,10 @@ public class ThinConnectionTest extends JDBCTestBase<ThinConnection> {
   private static int port = 8080;
   private static String debugTrans = "debugTrans";
   private static String maxRows = "100";
-  private static String windowRows = "1";
-  private static String windowTime = "2";
-  private static String windowRate = "3";
+  private static String windowMode = IDataServiceClientService.StreamingMode.ROW_BASED.toString();
+  private static String windowSize = "10";
+  private static String windowEvery = "5";
+  private static String windowLimit = "50000";
   private Matcher<String> noBangMatcher;
 
   private String url;
@@ -107,9 +109,10 @@ public class ThinConnectionTest extends JDBCTestBase<ThinConnection> {
     properties.setProperty( "user", "username" );
     properties.setProperty( "password", "password" );
     properties.setProperty( "maxrows", maxRows );
-    properties.setProperty( "windowrows", windowRows );
-    properties.setProperty( "windowtime", windowTime );
-    properties.setProperty( "windowrate", windowRate );
+    properties.setProperty( "windowmode", windowMode );
+    properties.setProperty( "windowsize", windowSize );
+    properties.setProperty( "windowevery", windowEvery );
+    properties.setProperty( "windowlimit", windowLimit );
 
     connection = new ThinConnection( url, URI.create( "http://localhost:8080/pentaho/kettle" ) );
     connection.setClientService( clientService );
@@ -142,9 +145,10 @@ public class ThinConnectionTest extends JDBCTestBase<ThinConnection> {
 
     assertEquals( "username", connection.getUsername() );
     assertEquals( maxRows, connection.getMaxRows() );
-    assertEquals( windowRows, connection.getWindowRows() );
-    assertEquals( windowTime, connection.getWindowTime() );
-    assertEquals( windowRate, connection.getWindowRate() );
+    assertEquals( windowMode, connection.getWindowMode() );
+    assertEquals( windowSize, connection.getWindowSize() );
+    assertEquals( windowEvery, connection.getWindowEvery() );
+    assertEquals( windowLimit, connection.getWindowLimit() );
 
     assertThat( connection.getDebugTransFilename(), is( debugTrans ) );
     assertEquals( false, connection.isLocal() );
@@ -183,9 +187,10 @@ public class ThinConnectionTest extends JDBCTestBase<ThinConnection> {
       put( "secure", "true" ).
       put( "local", "false" ).
       put( "maxRows", maxRows ).
-      put( "windowrows", windowRows ).
-      put( "windowtime", windowTime ).
-      put( "windowrate", windowRate ).
+      put( "windowmode", windowMode ).
+      put( "windowsize", windowSize ).
+      put( "windowevery", windowEvery ).
+      put( "windowlimit", windowLimit ).
       put( "PARAMETER_HELLO_WORLD", URLEncoder.encode( "test value", Charsets.UTF_8.name() ) ).
       build();
     url = "jdbc:pdi://localhost:8080/kettle?" + Joiner.on( "&" ).withKeyValueSeparator( "=" ).join( args );
@@ -200,9 +205,10 @@ public class ThinConnectionTest extends JDBCTestBase<ThinConnection> {
     assertEquals( port, thinConnection.getPort() );
     assertEquals( "username", thinConnection.getUsername() );
     assertEquals( maxRows, thinConnection.getMaxRows() );
-    assertEquals( windowRows, thinConnection.getWindowRows() );
-    assertEquals( windowTime, thinConnection.getWindowTime() );
-    assertEquals( windowRate, thinConnection.getWindowRate() );
+    assertEquals( windowMode, thinConnection.getWindowMode() );
+    assertEquals( windowSize, thinConnection.getWindowSize() );
+    assertEquals( windowEvery, thinConnection.getWindowEvery() );
+    assertEquals( windowLimit, thinConnection.getWindowLimit() );
     assertEquals( proxyHostName, thinConnection.getProxyHostname() );
     assertEquals( proxyPort, thinConnection.getProxyPort() );
     assertEquals( nonProxyHosts, thinConnection.getNonProxyHosts() );


### PR DESCRIPTION
Deppends on https://github.com/pentaho/pdi-dataservice-server-plugin/pull/312