### PR TITLE
[BACKLOG-24072] - Fixed the issue found by QA where masks with single quotes are not usable

### DIFF
--- a/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLCondition.java
+++ b/pdi-dataservice-client/src/main/java/org/pentaho/di/core/sql/SQLCondition.java
@@ -58,7 +58,7 @@ public class SQLCondition {
 
   private static final Pattern
     DATE_TO_STR_REGEX_PATTERN =
-    Pattern.compile( "(?i)^DATE_TO_STR\\s*\\(\\s*([^,]*)\\s*,?\\s*'?([^']*)'?\\s*\\)$" );
+    Pattern.compile( "(?i)^DATE_TO_STR\\s*\\(\\s*([^,]*)\\s*,?\\s*'?(([^']|'')*)'?\\s*\\)$" );
 
   public SQLCondition( String tableAlias, String conditionSql, RowMetaInterface serviceFields )
     throws KettleSQLException {
@@ -360,7 +360,7 @@ public class SQLCondition {
     Matcher dateToStrMatcher = DATE_TO_STR_REGEX_PATTERN.matcher( element );
     if ( dateToStrMatcher.matches() ) {
       String dateToStrFieldName = dateToStrMatcher.group( 1 );
-      String dateToStrMatcherValue = dateToStrMatcher.group( 2 );
+      String dateToStrMatcherValue = resolveEscapedSingleQuotes( dateToStrMatcher.group( 2 ) );
 
       // get clean field name
       dateToStrFieldName = getCleansedName( getAlias( dateToStrFieldName ).orElse( dateToStrFieldName ) );
@@ -383,6 +383,10 @@ public class SQLCondition {
     } else {
       return element;
     }
+  }
+
+  private String resolveEscapedSingleQuotes( String str ) {
+    return str.replaceAll( "''", "'" );
   }
 
   private void validateDateToStrField( String element, String dateToStrFieldName ) throws KettleSQLException {

--- a/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLConditionTest.java
+++ b/pdi-dataservice-client/src/test/java/org/pentaho/di/core/sql/SQLConditionTest.java
@@ -1148,4 +1148,29 @@ public class SQLConditionTest extends TestCase {
       assertTrue( kse.getMessage().contains( "Invalid field type" ) );
     }
   }
+
+  @Test
+  public void testDateToStrEscapedQuotes() throws KettleSQLException {
+    RowMetaInterface rowMeta = SQLTest.generateGettingStartedRowMeta();
+
+    /* simple quote */
+    SQLCondition sqlCondition = new SQLCondition(
+        "table", "STATE = DATE_TO_STR(ORDERDATE, 'yyyy-MM-dd''T''HH:mm:ss.SSSXXX')", rowMeta );
+
+    Collection<DateToStrFunction> functions = sqlCondition.getDateToStrFunctions();
+    assertTrue( functions.size() == 1 );
+
+    DateToStrFunction function = functions.iterator().next();
+    assertThat( function.getDateMask(), is( "yyyy-MM-dd'T'HH:mm:ss.SSSXXX" ) );
+
+    /* double quote */
+    SQLCondition sqlCondition2 = new SQLCondition(
+        "table", "STATE = DATE_TO_STR(ORDERDATE, 'hh ''o''''clock'' a, zzzz')", rowMeta );
+
+    Collection<DateToStrFunction> functions2 = sqlCondition2.getDateToStrFunctions();
+    assertTrue( functions2.size() == 1 );
+
+    DateToStrFunction function2 = functions2.iterator().next();
+    assertThat( function2.getDateMask(), is( "hh 'o''clock' a, zzzz" ) );
+  }
 }


### PR DESCRIPTION
Date format masks need to be able to contain single quote characters.
Solved by allowing single quote escape by doubling the occurences of single quote characters.
Eg. "yyyy-MM-dd'T'HH:mm:ss" becomes "yyy-MM-dd''T''HH:mm:ss".

[QA Issue](https://jira.pentaho.com/browse/BACKLOG-24210?focusedCommentId=345813&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-345813)