### PR TITLE
[PPP-4271] - Fixed Use of Vulnerable Component: xercesImpl-2.11.0 and…

### DIFF
--- a/pdi-dataservice-client/pom.xml
+++ b/pdi-dataservice-client/pom.xml
@@ -58,9 +58,6 @@
       </roles>
     </developer>
   </developers>
-  <properties>
-    <dependency.xerces.version>2.9.1</dependency.xerces.version>
-  </properties>
   <dependencies>
     <dependency>
       <groupId>pentaho-kettle</groupId>
@@ -117,7 +114,6 @@
     <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
-      <version>${dependency.xerces.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
… xercesImpl-2.9.1 (CVE-2013-4002 | CVE-2012-0881 | CVE-2009-2625 | sonatype-2017-0348)

Do not merge before https://github.com/pentaho/maven-parent-poms/pull/120.
This is a series of PRs to update Apache Xerces to version 2.12.0.

@pentaho-lmartins 