### PR TITLE
[PDI-17462] The "Pentaho-Data-Service-Driver" needs 3rd party jars

### DIFF
--- a/assemblies/driver/README.txt
+++ b/assemblies/driver/README.txt
@@ -1,3 +1,3 @@
 The pdi-dataservice-client zip contains all of the jar files required to make a JDBC connection to a running Data Service.
 
-Configuration documentation can be found at https://help.pentaho.com/Documentation/8.3/Products/Data_Integration/Data_Services/Optimize
+Configuration documentation can be found at https://help.pentaho.com/Documentation/8.3/Products/Data_Integration/Data_Services

--- a/assemblies/driver/src/assembly/assembly.xml
+++ b/assemblies/driver/src/assembly/assembly.xml
@@ -49,7 +49,7 @@
         <include>org.apache.httpcomponents:httpcore:*</include>
         <include>net.sf.scannotation:scannotation:*</include>
         <include>log4j:log4j:jar:*</include>
-        <include>javassist:javassist:*</include>
+        <include>org.javassist:javassist:*</include>
         <include>com.google.guava:guava:*</include>
         <include>org.slf4j:slf4j-api:*</include>
         <include>io.reactivex.rxjava2:rxjava:*</include>


### PR DESCRIPTION
Having fixed the missing jar, I was able to connect to a Pentaho Data Service using the following:
- DBeaver 6.0.5
- DbVisualizer Free 10.0.20
- SQuirreL 3.8.1
- RStudio 1.2.1335

Also fixed the link in the README.txt as the former link referred to a subset of the actual documentation.

@pentaho-lmartins @pentaho/tatooine 