### PR TITLE
[PDI-18093] Adding the java.sql.Driver service provider mechanism

### DIFF
--- a/pdi-dataservice-client/src/main/resources/META-INF/services/java.sql.Driver
+++ b/pdi-dataservice-client/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,0 +1,1 @@
+org.pentaho.di.trans.dataservice.jdbc.ThinDriver


### PR DESCRIPTION
Adds a service provider mechanism for some client tools ( one JDBC4 compliance issue ), but does not make the service JDBC4 compliant.