### PR TITLE
[BACKLOG-43874]-Fix JDK21 test pipeline(test1) build failures

### DIFF
--- a/assemblies/client/pom.xml
+++ b/assemblies/client/pom.xml
@@ -38,4 +38,15 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.karaf.tooling</groupId>
+        <artifactId>karaf-maven-plugin</artifactId>
+        <version>${karaf-maven-plugin.version}</version>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
[BACKLOG-43874]-Fix JDK21 test pipeline(test1) build failures

[BACKLOG-43874]: https://hv-eng.atlassian.net/browse/BACKLOG-43874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ