### PR TITLE
[BACKLOG-43902]-Java 21 : compatibility check for Pentaho and fix Build and Run time issues while building / testing

### DIFF
--- a/assemblies/client/pom.xml
+++ b/assemblies/client/pom.xml
@@ -48,6 +48,14 @@
           <allowIncompleteProjects>true</allowIncompleteProjects>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>${maven-deploy-plugin.version}</version>
+        <configuration>
+          <allowIncompleteProjects>true</allowIncompleteProjects>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/assemblies/client/pom.xml
+++ b/assemblies/client/pom.xml
@@ -41,10 +41,12 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.karaf.tooling</groupId>
-        <artifactId>karaf-maven-plugin</artifactId>
-        <version>${karaf-maven-plugin.version}</version>
-        <extensions>true</extensions>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>${maven-install-plugin.version}</version>
+        <configuration>
+          <allowIncompleteProjects>true</allowIncompleteProjects>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/assemblies/client/pom.xml
+++ b/assemblies/client/pom.xml
@@ -38,4 +38,15 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.karaf.tooling</groupId>
+        <artifactId>karaf-maven-plugin</artifactId>
+        <version>${karaf-maven-plugin.version}</version>
+        <extensions>true</extensions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
This pull request adds configuration to the Maven build process in the `assemblies/client/pom.xml` file. The main change is the inclusion of the `maven-install-plugin` and `maven-deploy-plugin` with the `allowIncompleteProjects` option enabled, which allows Maven to proceed with install and deploy phases even if some modules are incomplete.

Build configuration updates:

When using JDK 21, Maven enforces stricter validation on packaging types. If a module is configured with the packaging type feature (commonly used in Eclipse/Tycho-based builds), Maven fails with an error similar to:

"The packaging plugin for project  “**** " did not assign a main file to the project but it has attachments. Change packaging to 'pom'."

This occurs because feature is not a standard packaging type recognized by core Maven plugins. As a result, Maven is unable to process the module unless special handling is applied.

To minimize disruption while preserving product integrity, the identified solution is to configure:

`<allowIncompleteProjects>true</allowIncompleteProjects>`
within the maven-install-plugin and maven-deploy-plugin only for modules with packaging type feature.

This allows the build process to proceed seamlessly under JDK 21, while preserving existing module structure and functionality.